### PR TITLE
fix: resolve all remote archive paths

### DIFF
--- a/archive.py
+++ b/archive.py
@@ -49,7 +49,7 @@ def compute_priority(phase, gb_free, n_plots):
 
 def get_archdir_freebytes(arch_cfg):
     archdir_freebytes = { }
-    df_cmd = ('ssh %s@%s df -BK | grep " %s/"' %
+    df_cmd = ('ssh %s@%s df -aBK | grep " %s/"' %
         (arch_cfg['rsyncd_user'], arch_cfg['rsyncd_host'], arch_cfg['rsyncd_path']) )
     with subprocess.Popen(df_cmd, shell=True, stdout=subprocess.PIPE) as proc:
         for line in proc.stdout.readlines():


### PR DESCRIPTION
Adding `-a` to the `df` command args shows all mount points.

During archive operation, remote filesystems are queried for size information. Some mount points are not shown by the `df -BK` command, but are shown by adding `-a` like `df -aBK`. Perhaps this happens [when a device is mounted to two different locations with a parent/child relationship](https://www.suse.com/support/kb/doc/?id=000019022). This change lists all the mounted directories (even pseudo ones) and fixes the problem of hidden mounts for me in the plotman archive operation.