### PR TITLE
Use f_bavail instead of f_bfree

### DIFF
--- a/plot_util.py
+++ b/plot_util.py
@@ -7,7 +7,7 @@ GB = 1_000_000_000
 def df_b(d):
     'Return free space for directory (in bytes)'
     stat = os.statvfs(d)
-    return stat.f_frsize * stat.f_bfree 
+    return stat.f_frsize * stat.f_bavail
 
 def get_k32_plotsize():
     return 108 * GB


### PR DESCRIPTION
I noticed a discrepancy between the output of `df` and `GBfree` in plotman. Did a bit of digging and it turns out that df uses `f_bavail`, which doesn't include the blocks allocated to root, 5% of the total by default [0]. Plotman uses `f_bfree` which includes all blocks. I'm no linux expert but it seems more accurate to report the writable blocks. In fact, some people recommend removing the reserved blocks to unlock extra space [1].

This pr replaces the use of `f_bfree` with `f_bavail`. I'm not familiar enough with the whole codebase to know what kind of side effects this might have but I definitely prefer it for monitoring my plots.

[0] https://www.linuxquestions.org/questions/aix-43/diff-between-f_bavail-and-f_bfree-in-statfs-sys-call-207272/
[1] keybase://chat/chia_network.public#farming-hardware/11861
