### PR TITLE
Fix kill command so that it deletes all the temp files.

### DIFF
--- a/job.py
+++ b/job.py
@@ -289,10 +289,11 @@ class Job:
         self.proc.resume()
 
     def get_temp_files(self):
-        temp_files = []
+        # Prevent duplicate file paths by using set.
+        temp_files = set([])
         for f in self.proc.open_files():
             if self.tmpdir in f.path or self.tmp2dir in f.path or self.dstdir in f.path:
-                temp_files.append(f.path)
+                temp_files.add(f.path)
         return temp_files
 
     def cancel(self):


### PR DESCRIPTION
The get_temp_files function detects the log file open in twice so it was returning it twice, and the deletion of temporary files during the `kill` command was attempting to delete the log file twice which failed the second attempt. By returning all the temp files in a set, it only deletes each file once and succeeds in deleting all the temp files.