### PR TITLE
Development

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,6 +19,16 @@ directories:
                 - /mnt/tmp/02
                 - /mnt/tmp/03
 
+       # Optional: Allows overriding some characteristics of certain tmp
+       # directories. This contains a map of tmp directory names to
+       # attributes. If a tmp directory and attribute is not listed here,
+       # it uses the default attribute setting from the main configuration.
+       tmp_overrides:
+                # In this example, /mnt/tmp/00 is larger than the other tmp
+                # dirs and it can hold more plots than the default.
+                "/mnt/tmp/00":
+                        tmpdir_max_jobs: 5
+
         # Optional: tmp2 directory.  If specified, will be passed to
         # chia plots create as -2.  Only one tmp2 directory is supported.
         # tmp2: /mnt/tmp/a

--- a/interactive.py
+++ b/interactive.py
@@ -225,9 +225,9 @@ def curses_main(stdscr):
 
         # Dirs.  Collect reports as strings, then lay out.
         tmp_report_1 = reporting.tmp_dir_report(
-            jobs, dir_cfg['tmp'], sched_cfg, n_cols, 0, n_tmpdirs_half, tmp_prefix)
+            jobs, dir_cfg, sched_cfg, n_cols, 0, n_tmpdirs_half, tmp_prefix)
         tmp_report_2 = reporting.tmp_dir_report(
-            jobs, dir_cfg['tmp'], sched_cfg, n_cols, n_tmpdirs_half, n_tmpdirs, tmp_prefix)
+            jobs, dir_cfg, sched_cfg, n_cols, n_tmpdirs_half, n_tmpdirs, tmp_prefix)
 
         dst_report = reporting.dst_dir_report(
             jobs, dir_cfg['dst'], n_cols, dst_prefix)

--- a/manager.py
+++ b/manager.py
@@ -65,7 +65,7 @@ def phases_permit_new_job(phases, d, sched_cfg, dir_cfg):
     tmp_overrides = dir_cfg['tmp_overrides']
     if tmp_overrides is not None and d in tmp_overrides:
         overrides = tmp_overrides[d]
-        if 'max_plots' in overrides:
+        if 'tmpdir_max_jobs' in overrides:
             max_plots = overrides['tmpdir_max_jobs']
     if len(phases) >= max_plots:
         return False

--- a/manager.py
+++ b/manager.py
@@ -62,9 +62,11 @@ def phases_permit_new_job(phases, d, sched_cfg, dir_cfg):
     # Limit the total number of jobs per tmp dir. Default to the overall max jobs configuration,
     # but restrict to any configured overrides.
     max_plots = sched_cfg['tmpdir_max_jobs']
-    tmp_sizes = dir_cfg['tmp_sizes']
-    if tmp_sizes is not None and d in tmp_sizes:
-        max_plots = tmp_sizes[d]
+    tmp_overrides = dir_cfg['tmp_overrides']
+    if tmp_overrides is not None and d in tmp_overrides:
+        overrides = tmp_overrides[d]
+        if 'max_plots' in overrides:
+            max_plots = overrides['tmpdir_max_jobs']
     if len(phases) >= max_plots:
         return False
 

--- a/manager_test.py
+++ b/manager_test.py
@@ -11,6 +11,10 @@ class TestManager(unittest.TestCase):
                 'tmpdir_stagger_phase_major': 3,
                 'tmpdir_stagger_phase_minor': 0,
                 'tmpdir_max_jobs': 3 }
+        self.dir_cfg = {
+                'tmp_overrides': {
+                        '/mnt/tmp/04': {
+                                'tmpdir_max_jobs': 4 }}}
 
     @patch('job.Job')
     def job_w_tmpdir_phase(self, tmpdir, phase, MockJob):
@@ -28,15 +32,24 @@ class TestManager(unittest.TestCase):
 
     def test_permit_new_job_post_milestone(self):
         self.assertTrue(manager.phases_permit_new_job(
-            [ (3, 8), (4, 1) ], self.sched_cfg ))
+            [ (3, 8), (4, 1) ], '/mnt/tmp/00', self.sched_cfg, self.dir_cfg))
 
     def test_permit_new_job_pre_milestone(self):
         self.assertFalse(manager.phases_permit_new_job(
-            [ (2, 3), (4, 1) ], self.sched_cfg ))
+            [ (2, 3), (4, 1) ], '/mnt/tmp/00', self.sched_cfg, self.dir_cfg))
 
     def test_permit_new_job_too_many_jobs(self):
         self.assertFalse(manager.phases_permit_new_job(
-            [ (3, 1), (3, 2), (3, 3) ], self.sched_cfg ))
+            [ (3, 1), (3, 2), (3, 3) ], '/mnt/tmp/00', self.sched_cfg,
+            self.dir_cfg))
+
+    def test_permit_new_job_override_tmp_dir(self):
+        self.assertTrue(manager.phases_permit_new_job(
+            [ (3, 1), (3, 2), (3, 3) ], '/mnt/tmp/04', self.sched_cfg,
+            self.dir_cfg))
+        self.assertFalse(manager.phases_permit_new_job(
+            [ (3, 1), (3, 2), (3, 3), (3, 6) ], '/mnt/tmp/04', self.sched_cfg,
+            self.dir_cfg))
 
     def test_dstdirs_to_furthest_phase(self):
         all_jobs = [ self.job_w_dstdir_phase('/plots1', (1, 5)),

--- a/reporting.py
+++ b/reporting.py
@@ -120,18 +120,19 @@ def status_report(jobs, width, height=None, tmp_prefix='', dst_prefix=''):
     # return ('tmp dir prefix: %s ; dst dir prefix: %s\n' % (tmp_prefix, dst_prefix)
     return tab.draw()
 
-def tmp_dir_report(jobs, tmpdirs, sched_cfg, width, start_row=None, end_row=None, prefix=''):
+def tmp_dir_report(jobs, dir_cfg, sched_cfg, width, start_row=None, end_row=None, prefix=''):
     '''start_row, end_row let you split the table up if you want'''
     tab = tt.Texttable()
     headings = ['tmp', 'ready', 'phases']
     tab.header(headings)
     tab.set_cols_dtype('t' * len(headings))
     tab.set_cols_align('r' * (len(headings) - 1) + 'l')
+    tmpdirs = dir_cfg['tmp']
     for i, d in enumerate(sorted(tmpdirs)):
         if (start_row and i < start_row) or (end_row and i >= end_row):
             continue
         phases = sorted(job.job_phases_for_tmpdir(d, jobs))
-        ready = manager.phases_permit_new_job(phases, sched_cfg)
+        ready = manager.phases_permit_new_job(phases, d, sched_cfg, dir_cfg)
         row = [abbr_path(d, prefix), 'OK' if ready else '--', phases_str(phases)]
         tab.add_row(row)
 
@@ -186,7 +187,7 @@ def dirs_report(jobs, dir_cfg, sched_cfg, width):
     tmpdirs = dir_cfg['tmp']
     dstdirs = dir_cfg['dst']
     arch_cfg = dir_cfg['archive']
-    return (tmp_dir_report(jobs, tmpdirs, sched_cfg, width) + '\n' +
+    return (tmp_dir_report(jobs, dir_cfg, sched_cfg, width) + '\n' +
             dst_dir_report(jobs, dstdirs, width) + '\n' +
             'archive dirs free space:\n' +
             arch_dir_report(archive.get_archdir_freebytes(arch_cfg), width) + '\n')


### PR DESCRIPTION
Allow a different number of plots per tmp dir.

This sets up a pattern of overriding certain parameters per tmp file. In this case, the max number of jobs per tmp file defaults to the scheduler config 'tmpdir_max_jobs', but allows each tmp dir to override with it's own unique value for max jobs. This same pattern could be used to specialize other attributes per tmp dir.

The main use for this is for handling heterogeneous sizes of tmp drives with a single plotman configuration. For example, this would make it easy to support both 1TB, 2TB, and 6.4TB tmp dirs in the same configuration while fully utilizing the available space of each.