### PR TITLE
missing processes need to be ignored

### DIFF
--- a/archive.py
+++ b/archive.py
@@ -74,11 +74,12 @@ def get_running_archive_jobs(arch_cfg):
     jobs = []
     dest = rsync_dest(arch_cfg, '/')
     for proc in psutil.process_iter(['pid', 'name']):
-        if proc.name() == 'rsync':
-            args = proc.cmdline()
-            for arg in args:
-                if arg.startswith(dest):
-                    jobs.append(proc.pid)
+        with contextlib.suppress(psutil.NoSuchProcess):
+            if proc.name() == 'rsync':
+                args = proc.cmdline()
+                for arg in args:
+                    if arg.startswith(dest):
+                        jobs.append(proc.pid)
     return jobs
 
 def archive(dir_cfg, all_jobs):


### PR DESCRIPTION
as in job.py - archive.py also needs a catch/ignore for "psutil.NoSuchProcess"
