### PR TITLE
quick fix for #41 which can handle the no-space case for known arg keys.

### DIFF
--- a/job.py
+++ b/job.py
@@ -33,6 +33,17 @@ def is_plotting_cmdline(cmdline):
         and 'create' == cmdline[3]
     )
 
+# This is a (temporary?) fix for https://github.com/ericaltendorf/plotman/issues/41
+def cmdline_argfix(cmdline):
+    known_keys = 'krbut2dne'
+    for i in cmdline:
+        if i[0]=='-' and i[1] in known_keys and len(i)>2:
+            key = i[0:2]
+            val = i[2:]
+            cmdline[cmdline.index(i)] = key
+            cmdline.insert(cmdline.index(key)+1, val)
+    return cmdline
+
 # TODO: be more principled and explicit about what we cache vs. what we look up
 # dynamically from the logfile
 class Job:
@@ -88,7 +99,7 @@ class Job:
             assert 'chia' in args[1]
             assert 'plots' == args[2]
             assert 'create' == args[3]
-            args_iter = iter(args[4:])
+            args_iter = iter(cmdline_argfix(args[4:]))
             for arg in args_iter:
                 val = None if arg in ['-e'] else next(args_iter)
                 if arg == '-k':


### PR DESCRIPTION
As discussed on keybase.

This breaks up known "chia plot create" arguments when they don't contain a space character between key and value, to prevent faulty arg handling by the Job class.

Example:
```python
>>> cmdline = ['/chia-blockchain/venv/bin/python3.8', 'venv/bin/chia', 'plots', 'create', '-n1', '-k32', '-r12', '-t/plots/tmp', 
'-2/plots/tmp', '-d/plots', '-b9216']
```
Would usually result in faulty parsing and a `StopIteration` exception in job.py line 105:
```
Warning: unrecognized args: -k32 -r
Warning: unrecognized args: 12 -t
Warning: unrecognized args: /plots/tmp -2
Warning: unrecognized args: /plots/tmp -d
Warning: unrecognized args: /plots -b
```
i.e. completely mismatched argument keys/values.
Solution:
```python
>>> cmdline_argfix(cmdline)
['/chia-blockchain/venv/bin/python3.8', 'venv/bin/chia', 'plots', 'create', '-n', '1', '-k', '32', '-r', '12', '-t', '/plots/tmp', '-2', '/plots/tmp', '-d', '/plots', '-b', '9216']
```