### PR TITLE
Handle spaceless args like '-k32', not just '-k 32'

### DIFF
--- a/job.py
+++ b/job.py
@@ -35,9 +35,14 @@ def is_plotting_cmdline(cmdline):
 def cmdline_argfix(cmdline):
     known_keys = 'krbut2dne'
     for i in cmdline:
+        # If the argument starts with dash and a known key and is longer than 2,
+        # then an argument is passed with no space between its key and value.
+        # This is POSIX compliant but the arg parser was tripping over it.
+        # In these cases, splitting that item up in separate key and value
+        # elements results in a `cmdline` list that is correctly formatted.
         if i[0]=='-' and i[1] in known_keys and len(i)>2:
-            yield i[0:2]
-            yield i[2:]
+            yield i[0:2]  # key
+            yield i[2:]  # value
         else:
             yield i
 

--- a/job.py
+++ b/job.py
@@ -31,6 +31,16 @@ def is_plotting_cmdline(cmdline):
         and 'create' == cmdline[3]
     )
 
+# This is a cmdline argument fix for https://github.com/ericaltendorf/plotman/issues/41
+def cmdline_argfix(cmdline):
+    known_keys = 'krbut2dne'
+    for i in cmdline:
+        if i[0]=='-' and i[1] in known_keys and len(i)>2:
+            yield i[0:2]
+            yield i[2:]
+        else:
+            yield i
+
 # TODO: be more principled and explicit about what we cache vs. what we look up
 # dynamically from the logfile
 class Job:
@@ -86,7 +96,7 @@ class Job:
             assert 'chia' in args[1]
             assert 'plots' == args[2]
             assert 'create' == args[3]
-            args_iter = iter(args[4:])
+            args_iter = iter(cmdline_argfix(args[4:]))
             for arg in args_iter:
                 val = None if arg in ['-e'] else next(args_iter)
                 if arg == '-k':


### PR DESCRIPTION
Redid #59 based on the development branch, and improved implementation based on @altendky's feedback.
Fixes #41.

---

This breaks up known `chia plot create` arguments when they don't contain a space character between key and value, to prevent faulty arg handling by the Job class.

Example:
```python
>>> cmdline = ['/chia-blockchain/venv/bin/python3.8', 'venv/bin/chia', 'plots', 'create', '-n1', '-k32', '-r12', '-t/plots/tmp', 
'-2/plots/tmp', '-d/plots', '-b9216']
```
This would usually result in faulty parsing and a `StopIteration` exception in job.py line 105:
```
Warning: unrecognized args: -k32 -r
Warning: unrecognized args: 12 -t
Warning: unrecognized args: /plots/tmp -2
Warning: unrecognized args: /plots/tmp -d
Warning: unrecognized args: /plots -b
```
i.e. completely mismatched argument keys/values.
Solution:
```python
>>> cmdline_argfix(cmdline)
['/chia-blockchain/venv/bin/python3.8', 'venv/bin/chia', 'plots', 'create', '-n', '1', '-k', '32', '-r', '12', '-t', '/plots/tmp', '-2', '/plots/tmp', '-d', '/plots', '-b', '9216']
``` 