### PR TITLE
fix: acknowledge any chia command instead of requiring venv/bin/chia

### DIFF
--- a/job.py
+++ b/job.py
@@ -26,7 +26,7 @@ def is_plotting_cmdline(cmdline):
     return (
         len(cmdline) >= 4
         and 'python' in cmdline[0]
-        and 'venv/bin/chia' in cmdline[1]
+        and cmdline[1].endswith('/chia')
         and 'plots' == cmdline[2]
         and 'create' == cmdline[3]
     )


### PR DESCRIPTION
Maybe someday we use pathlib everywhere, but for now this cuts it.