### PR TITLE
Drop Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,6 @@ jobs:
           - name: Linux
             runs-on: ubuntu-latest
         python:
-          - name: CPython 3.6
-            tox: py36
-            action: 3.6
           - name: CPython 3.7
             tox: py37
             action: 3.7
@@ -93,9 +90,6 @@ jobs:
           - name: CPython 3.9
             tox: py39
             action: 3.9
-          - name: PyPy 3.6
-            tox: pypy36
-            action: pypy-3.6
           - name: PyPy 3.7
             tox: pypy37
             action: pypy-3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ long-description = file: README.md
 long_description_content_type = text/markdown
 license = Apache 2.0
 license-file = LICENSE
+python_requires = >=3.7
 keywords = chia, blockchain, automation, process management
 classifiers =
     Development Status :: 3 - Alpha

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = test-py{36,37,38,39,py36,py37}
+envlist = test-py{37,38,39,py37}
 
 [testenv]
 changedir = {envtmpdir}


### PR DESCRIPTION
@jkbecker wins.  There are various tidbits in 3.7 that will be nice to have around.  Specifically `importlib.resources` for the example log file in #93.