### PR TITLE
Ignore -h/--help plot processes

### DIFF
--- a/src/plotman/job.py
+++ b/src/plotman/job.py
@@ -66,6 +66,7 @@ class Job:
     job_id = 0
     plot_id = '--------'
     proc = None   # will get a psutil.Process
+    help = False
 
     # These are dynamic, cached, and need to be udpated periodically
     phase = (None, None)   # Phase/subphase
@@ -85,7 +86,9 @@ class Job:
                     if proc.pid in cached_jobs_by_pid.keys():
                         jobs.append(cached_jobs_by_pid[proc.pid])  # Copy from cache
                     else:
-                        jobs.append(Job(proc, logroot))
+                        job = Job(proc, logroot)
+                        if not job.help:
+                            jobs.append(job)
 
         return jobs
 
@@ -104,7 +107,7 @@ class Job:
             assert 'create' == args[3]
             args_iter = iter(cmdline_argfix(args[4:]))
             for arg in args_iter:
-                val = None if arg in ['-e', '--override-k'] else next(args_iter)
+                val = None if arg in ['-e', '-h', '--help', '--override-k'] else next(args_iter)
                 if arg == '-k':
                     self.k = val
                 elif arg == '-r':
@@ -121,6 +124,8 @@ class Job:
                     self.dstdir = val
                 elif arg == '-n':
                     self.n = val
+                elif arg in {'-h', '--help'}:
+                    self.help = True
                 elif arg == '-e' or arg == '-f' or arg == '-p':
                     pass
                     # TODO: keep track of these


### PR DESCRIPTION
This is an alternative to https://github.com/ericaltendorf/plotman/pull/51.

Reference traceback:
```python-traceback
Traceback (most recent call last):
  File "/farm/venv/bin/plotman", line 33, in <module>
    sys.exit(load_entry_point('plotman', 'console_scripts', 'plotman')())
  File "/farm/plotman/src/plotman/plotman.py", line 136, in main
    interactive.run_interactive()
  File "/farm/plotman/src/plotman/interactive.py", line 362, in run_interactive
    curses.wrapper(curses_main)
  File "/home/altendky/.pyenv/versions/3.9.2/lib/python3.9/curses/__init__.py", line 94, in wrapper
    return func(stdscr, *args, **kwds)
  File "/farm/plotman/src/plotman/interactive.py", line 116, in curses_main
    jobs = Job.get_running_jobs(dir_cfg['log'], cached_jobs=jobs)
  File "/farm/plotman/src/plotman/job.py", line 88, in get_running_jobs
    jobs.append(Job(proc, logroot))
  File "/farm/plotman/src/plotman/job.py", line 107, in __init__
    val = None if arg in ['-e'] else next(args_iter)
StopIteration
```