### PR TITLE
yield configuration path in configuration path fixture

### DIFF
--- a/src/plotman/_tests/configuration_test.py
+++ b/src/plotman/_tests/configuration_test.py
@@ -12,7 +12,7 @@ from plotman import resources as plotman_resources
 def config_fixture(tmp_path):
     """Return direct path to plotman.yaml"""
     with importlib.resources.path(plotman_resources, "plotman.yaml") as path:
-        return path
+        yield path
 
 
 def test_get_validated_configs__default(mocker, config_path):


### PR DESCRIPTION
https://docs.python.org/3.9/library/importlib.html#importlib.resources.path

If needed, importlib.resources.path() will write the resources to a temporary location.  This will be cleaned up after exiting the context manager.  Using yield leaves the fixture 'in' the context manager until the fixture is cleaned up.