### PR TITLE
change farmer_pk and pool_pk to type str

### DIFF
--- a/src/plotman/configuration.py
+++ b/src/plotman/configuration.py
@@ -77,8 +77,8 @@ class Plotting:
     n_threads: int
     n_buckets: int
     job_buffer: int
-    farmer_pk: Optional[int] = None
-    pool_pk: Optional[int] = None
+    farmer_pk: Optional[str] = None
+    pool_pk: Optional[str] = None
 
 @dataclass
 class UserInterface:


### PR DESCRIPTION
currently when supplying these values you get the following exception:
```
marshmallow.exceptions.ValidationError: {'plotting': {'farmer_pk': ['Not a valid integer.'], 'pool_pk': ['Not a valid integer.']}}
```