### PR TITLE
Add configuration to exclude full dst directories (#121)

### DIFF
--- a/src/plotman/_tests/manager_test.py
+++ b/src/plotman/_tests/manager_test.py
@@ -14,7 +14,8 @@ def sched_cfg():
         polling_time_s=2,
         tmpdir_stagger_phase_major=3,
         tmpdir_stagger_phase_minor=0,
-        tmpdir_max_jobs=3
+        tmpdir_max_jobs=3,
+        stop_when_dst_full=False
     )
 
 @pytest.fixture

--- a/src/plotman/archive.py
+++ b/src/plotman/archive.py
@@ -121,8 +121,7 @@ def archive(dir_cfg, all_jobs):
         return(False, 'No free archive dirs found.')
     
     archdir = ''
-    available = [(d, space) for (d, space) in archdir_freebytes.items() if 
-                 space > 1.2 * plot_util.get_k32_plotsize()]
+    available = [(d, space) for (d, space) in archdir_freebytes.items() if plot_util.enough_space_for_k32(space)]
     if len(available) > 0:
         index = min(dir_cfg.archive.index, len(available) - 1)
         (archdir, freespace) = sorted(available)[index]

--- a/src/plotman/configuration.py
+++ b/src/plotman/configuration.py
@@ -69,6 +69,7 @@ class Scheduling:
     tmpdir_stagger_phase_major: int
     tmpdir_stagger_phase_minor: int
     tmpdir_stagger_phase_limit: int = 1  # If not explicit, "tmpdir_stagger_phase_limit" will default to 1
+    stop_when_dst_full: bool = False
 
 @dataclass
 class Plotting:

--- a/src/plotman/manager.py
+++ b/src/plotman/manager.py
@@ -84,21 +84,23 @@ def maybe_start_new_plot(dir_cfg, sched_cfg, plotting_cfg):
                 if phases_permit_new_job(phases, d, sched_cfg, dir_cfg) ]
         rankable = [ (d, phases[0]) if phases else (d, (999, 999))
                 for (d, phases) in eligible ]
-        
-        if not eligible:
+        dir2ph = {d: ph for (d, ph) in dstdirs_to_youngest_phase(jobs).items()
+                  if (d in dir_cfg.dst and plot_util.is_valid_plot_dst(d, sched_cfg))}
+        unused_dirs = [d for d in dir_cfg.dst
+                       if d not in dir2ph.keys() and plot_util.is_valid_plot_dst(d, sched_cfg)]
+
+        if not unused_dirs and not dir2ph:
+            wait_reason = 'no eligible dstdirs'
+        elif not eligible:
             wait_reason = 'no eligible tempdirs'
         else:
             # Plot to oldest tmpdir.
             tmpdir = max(rankable, key=operator.itemgetter(1))[0]
 
-            # Select the dst dir least recently selected
-            dir2ph = { d:ph for (d, ph) in dstdirs_to_youngest_phase(jobs).items()
-                      if d in dir_cfg.dst }
-            unused_dirs = [d for d in dir_cfg.dst if d not in dir2ph.keys()]
-            dstdir = ''
-            if unused_dirs: 
+            if unused_dirs:
                 dstdir = random.choice(unused_dirs)
             else:
+                # Select the dst dir least recently selected
                 dstdir = max(dir2ph, key=dir2ph.get)
 
             logfile = os.path.join(

--- a/src/plotman/plot_util.py
+++ b/src/plotman/plot_util.py
@@ -12,6 +12,17 @@ def df_b(d):
 def get_k32_plotsize():
     return 108 * GB
 
+def is_valid_plot_dst(d, sched_cfg):
+    return (not sched_cfg.stop_when_dst_full) or dir_can_recieve_k32(d)
+
+def dir_can_recieve_k32(d):
+    'Determine if there is enough space for a k32 in a directory'
+    return enough_space_for_k32(df_b(d))
+
+def enough_space_for_k32(b):
+    'Determine if there is enough space for a k32 given a number of free bytes'
+    return b > 1.2 * get_k32_plotsize()
+
 def human_format(num, precision):
     magnitude = 0
     while abs(num) >= 1000:

--- a/src/plotman/resources/plotman.yaml
+++ b/src/plotman/resources/plotman.yaml
@@ -103,6 +103,10 @@ scheduling:
         # How often the daemon wakes to consider starting a new plot job
         polling_time_s: 20
 
+        # Stop initiating new plots when a dst is full, default to False since
+        # archiving job should move other plots before plotting is completed
+        stop_when_dst_full: False
+
 
 # Plotting parameters.  These are pass-through parameters to chia plots create.
 # See documentation at


### PR DESCRIPTION
This consolidates free space evaluation into `plot_util` and adds a configuration point to not plot to a destination directory that is full.