### PR TITLE
Update process detection logic to work on OSX

### DIFF
--- a/src/plotman/job.py
+++ b/src/plotman/job.py
@@ -27,7 +27,7 @@ def job_phases_for_dstdir(d, all_jobs):
 def is_plotting_cmdline(cmdline):
     return (
         len(cmdline) >= 4
-        and 'python' in cmdline[0]
+        and 'python' in cmdline[0].lower()
         and cmdline[1].endswith('/chia')
         and 'plots' == cmdline[2]
         and 'create' == cmdline[3]

--- a/src/plotman/job.py
+++ b/src/plotman/job.py
@@ -106,7 +106,7 @@ class Job:
             # Parse command line args
             args = self.proc.cmdline()
             assert len(args) > 4
-            assert 'python' in args[0]
+            assert 'python' in args[0].lower()
             assert 'chia' in args[1]
             assert 'plots' == args[2]
             assert 'create' == args[3]


### PR DESCRIPTION
the arguments passed to this function looked like this on OSX:

`['/Library/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python', '/Users/chia/chia-blockchain/venv/bin/chia', 'plots', 'create', '-k', '32', '-r', '2', '-u', '128', '-b', '4608', '-t', '/Volumes/plotting2tb', '-d', '/Volumes/16tb']`

The first argument did not contain a lowercase 'python', so we can lowercase the string before comparison to make the check work more generally.