### PR TITLE
Update default buffer option to 3389 to match Chia default

### DIFF
--- a/src/plotman/resources/plotman.yaml
+++ b/src/plotman/resources/plotman.yaml
@@ -112,7 +112,7 @@ plotting:
         e: False             # Use -e plotting option
         n_threads: 2         # Threads per job
         n_buckets: 128       # Number of buckets to split data into
-        job_buffer: 4608     # Per job memory
+        job_buffer: 3389     # Per job memory
         # If specified, pass through to the -f and -p options.  See CLI reference.
         #   farmer_pk: ...
         #   pool_pk: ...


### PR DESCRIPTION
As per the [previous PR](https://github.com/ericaltendorf/plotman/pull/139), Plotman's default config should track the default Chia options to make things simpler.  As per 1.1.2, Chia actually defaults to 3389 for the buffer: https://github.com/Chia-Network/chia-blockchain/commit/d0649fb57407cfffbaec7baeba86fd76ecb51770