### PR TITLE
Add `tmpdir_stagger_phase_limit` to overrides

### DIFF
--- a/src/plotman/configuration.py
+++ b/src/plotman/configuration.py
@@ -50,6 +50,7 @@ class Archive:
 @dataclass
 class TmpOverrides:
     tmpdir_max_jobs: Optional[int] = None
+    tmpdir_stagger_phase_limit: Optional[int] = None
 
 @dataclass
 class Directories:

--- a/src/plotman/manager.py
+++ b/src/plotman/manager.py
@@ -50,18 +50,23 @@ def phases_permit_new_job(phases, d, sched_cfg, dir_cfg):
     if len(phases) == 0:
         return True
 
+    curr_overrides = None
+    if dir_cfg.tmp_overrides is not None and d in dir_cfg.tmp_overrides:
+        curr_overrides = dir_cfg.tmp_overrides[d]
+
     milestone = (sched_cfg.tmpdir_stagger_phase_major, sched_cfg.tmpdir_stagger_phase_minor)
     # tmpdir_stagger_phase_limit default is 1, as declared in configuration.py
-    if len([p for p in phases if p < milestone]) >= sched_cfg.tmpdir_stagger_phase_limit:
+    tmpdir_stagger_limit = sched_cfg.tmpdir_stagger_phase_limit
+    if curr_overrides and curr_overrides.tmpdir_stagger_phase_limit is not None:
+        tmpdir_stagger_limit = curr_overrides.tmpdir_stagger_phase_limit
+    if len([p for p in phases if p < milestone]) >= tmpdir_stagger_limit:
         return False
 
     # Limit the total number of jobs per tmp dir. Default to the overall max
     # jobs configuration, but restrict to any configured overrides.
     max_plots = sched_cfg.tmpdir_max_jobs
-    if dir_cfg.tmp_overrides is not None and d in dir_cfg.tmp_overrides:
-        curr_overrides = dir_cfg.tmp_overrides[d]
-        if curr_overrides.tmpdir_max_jobs is not None:
-            max_plots = curr_overrides.tmpdir_max_jobs
+    if curr_overrides and curr_overrides.tmpdir_max_jobs is not None:
+        max_plots = curr_overrides.tmpdir_max_jobs
     if len(phases) >= max_plots:
         return False
 


### PR DESCRIPTION
This PR adds `tmpdir_stagger_phase_limit` to `TmpOverrides` and updates `phases_permit_new_job` as needed. This allows setting different phase limits for different size/speed drives.

Have been testing this and it works as expected.