### PR TITLE
fix: explain failure to open new log files

### DIFF
--- a/src/plotman/manager.py
+++ b/src/plotman/manager.py
@@ -126,11 +126,27 @@ def maybe_start_new_plot(dir_cfg, sched_cfg, plotting_cfg):
 
             logmsg = ('Starting plot job: %s ; logging to %s' % (' '.join(plot_args), logfile))
 
-            # start_new_sessions to make the job independent of this controlling tty.
-            p = subprocess.Popen(plot_args,
-                stdout=open(logfile, 'w'),
-                stderr=subprocess.STDOUT,
-                start_new_session=True)
+            try:
+                open_log_file = open(logfile, 'w')
+            except FileNotFoundError as e:
+                message = (
+                    f'Unable to open log file.  Verify that the directory exists'
+                    f' and has proper write permissions: {logfile!r}'
+                )
+                raise Exception(message) from e
+
+            # Preferably, do not add any code between the try block above
+            # and the with block below.  IOW, this space intentionally left
+            # blank...  As is, this provides a good chance that our handle
+            # of the log file will get closed explicitly while still
+            # allowing handling of just the log file opening error.
+                
+            with open_log_file:
+                # start_new_sessions to make the job independent of this controlling tty.
+                p = subprocess.Popen(plot_args,
+                    stdout=open_log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True)
 
             psutil.Process(p.pid).nice(15)
             return (True, logmsg)


### PR DESCRIPTION
I specifically chose this explanatory error over just creating the directory.  Since the common cause is not having created the directory, or having misconfigured the path, this should only generally happen 'once'.  As such, retaining the reminder in case of misconfiguration seems sufficiently useful to overcome the hassle in cases where the directory just hadn't been created.

Draft for:
- [ ] Self testing