### PR TITLE
allow empty dst directory, if so, the tmp directory is used as buffer.

### DIFF
--- a/src/plotman/archive.py
+++ b/src/plotman/archive.py
@@ -96,8 +96,8 @@ def archive(dir_cfg, all_jobs):
     dir2ph = manager.dstdirs_to_furthest_phase(all_jobs)
     best_priority = -100000000
     chosen_plot = None
-
-    for d in dir_cfg.dst:
+    (is_dst, dst_dir) = configuration.get_dst_directories(dir_cfg)
+    for d in dst_dir:
         ph = dir2ph.get(d, (0, 0))
         dir_plots = plot_util.list_k32_plots(d)
         gb_free = plot_util.df_b(d) / plot_util.GB

--- a/src/plotman/configuration.py
+++ b/src/plotman/configuration.py
@@ -35,6 +35,13 @@ def get_validated_configs():
     except marshmallow.exceptions.ValidationError as e:
         raise ConfigurationException(f"Config file at: '{config_file_path}' is malformed") from e
 
+def get_dst_directories(dir_cfg):
+    """Returns either (True, <Directories.dst>) or (False, <Directories.tmp>). If Directories.dst is None,
+    Use Directories.tmp as dst directory."""
+    if dir_cfg.dst is None:
+        (False, dir_cfg.tmp)
+    else:
+        (True, dir_cfg.dst)
 
 # Data models used to deserializing/formatting plotman.yaml files.
 
@@ -55,7 +62,7 @@ class TmpOverrides:
 class Directories:
     log: str
     tmp: List[str]
-    dst: List[str]
+    dst: Optional[List[str]] = None
     tmp2: Optional[str] = None
     tmp_overrides: Optional[Dict[str, TmpOverrides]] = None
     archive: Optional[Archive] = None

--- a/src/plotman/interactive.py
+++ b/src/plotman/interactive.py
@@ -173,7 +173,8 @@ def curses_main(stdscr):
 
         # Directory prefixes, for abbreviation
         tmp_prefix = os.path.commonpath(cfg.directories.tmp)
-        dst_prefix = os.path.commonpath(cfg.directories.dst)
+        (is_dst, dst_dir) = configuration.get_dst_directories(cfg.directories)
+        dst_prefix = os.path.commonpath(dst_dir)
         if archiving_configured:
             arch_prefix = cfg.directories.archive.rsyncd_path
 
@@ -186,7 +187,7 @@ def curses_main(stdscr):
         tmp_report_2 = reporting.tmp_dir_report(
             jobs, cfg.directories, cfg.scheduling, n_cols, n_tmpdirs_half, n_tmpdirs, tmp_prefix)
         dst_report = reporting.dst_dir_report(
-            jobs, cfg.directories.dst, n_cols, dst_prefix)
+            jobs, dst_dir, n_cols, dst_prefix)
         if archiving_configured:
             arch_report = reporting.arch_dir_report(archdir_freebytes, n_cols, arch_prefix)
             if not arch_report:

--- a/src/plotman/manager.py
+++ b/src/plotman/manager.py
@@ -92,14 +92,18 @@ def maybe_start_new_plot(dir_cfg, sched_cfg, plotting_cfg):
             tmpdir = max(rankable, key=operator.itemgetter(1))[0]
 
             # Select the dst dir least recently selected
-            dir2ph = { d:ph for (d, ph) in dstdirs_to_youngest_phase(jobs).items()
-                      if d in dir_cfg.dst }
-            unused_dirs = [d for d in dir_cfg.dst if d not in dir2ph.keys()]
-            dstdir = ''
-            if unused_dirs: 
-                dstdir = random.choice(unused_dirs)
+            (is_dst, dst_dir) = configuration.get_dst_directories(dir_cfg)
+            if is_dst:
+                dir2ph = { d:ph for (d, ph) in dstdirs_to_youngest_phase(jobs).items()
+                        if d in dst_dir }
+                unused_dirs = [d for d in dst_dir if d not in dir2ph.keys()]
+                dstdir = ''
+                if unused_dirs: 
+                    dstdir = random.choice(unused_dirs)
+                else:
+                    dstdir = max(dir2ph, key=dir2ph.get)
             else:
-                dstdir = max(dir2ph, key=dir2ph.get)
+                dstdir = tmpdir
 
             logfile = os.path.join(
                 dir_cfg.log, datetime.now().strftime('%Y-%m-%d-%H:%M:%S.log')

--- a/src/plotman/reporting.py
+++ b/src/plotman/reporting.py
@@ -186,9 +186,10 @@ def arch_dir_report(archdir_freebytes, width, prefix=''):
 
 # TODO: remove this
 def dirs_report(jobs, dir_cfg, sched_cfg, width):
+    (is_dst, dst_dir) = configuration.get_dst_directories(dir_cfg)
     return (
         tmp_dir_report(jobs, dir_cfg, sched_cfg, width) + '\n' +
-        dst_dir_report(jobs, dir_cfg.dst, width) + '\n' +
+        dst_dir_report(jobs, dst_dir, width) + '\n' +
         'archive dirs free space:\n' +
         arch_dir_report(archive.get_archdir_freebytes(dir_cfg.archive), width) + '\n'
     )

--- a/src/plotman/resources/plotman.yaml
+++ b/src/plotman/resources/plotman.yaml
@@ -47,10 +47,11 @@ directories:
         # chia plots create as -2.  Only one tmp2 directory is supported.
         # tmp2: /mnt/tmp/a
 
-        # One or more directories; the scheduler will use all of them.
+        # Optional: One or more directories; the scheduler will use all of them.
         # These again are presumed to be on independent physical devices,
         # so writes (plot jobs) and reads (archivals) can be scheduled
         # to minimize IO contention.
+        # if no dst directory is listed, the tmp directories will be used as buffer.
         dst:
                 - /mnt/dst/00
                 - /mnt/dst/01


### PR DESCRIPTION
set dst directory to optional, if directory.dst is None, no buffer will be used, chia plot command will set dst directory to tmp directory. 
If multiple fast M.2(>3000M/s) ssd is used and not raid, archive directly from the tmp directory can save disk and time.