### PR TITLE
run in vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__
 venv
+.DS_Store
+.vscode

--- a/src/plotman/archive.py
+++ b/src/plotman/archive.py
@@ -58,7 +58,7 @@ def get_archdir_freebytes(arch_cfg):
                 # not actually mounted
                 continue
             freebytes = int(fields[3][:-1]) * 1024  # Strip the final 'K'
-            archdir = (fields[5]).decode('ascii')
+            archdir = (fields[5]).decode('utf-8')
             archdir_freebytes[archdir] = freebytes
     return archdir_freebytes
 

--- a/src/plotman/job.py
+++ b/src/plotman/job.py
@@ -27,7 +27,7 @@ def job_phases_for_dstdir(d, all_jobs):
 def is_plotting_cmdline(cmdline):
     return (
         len(cmdline) >= 4
-        and 'python' in cmdline[0]
+        and ('python' in cmdline[0] or 'Python' in cmdline[0])
         and cmdline[1].endswith('/chia')
         and 'plots' == cmdline[2]
         and 'create' == cmdline[3]
@@ -106,7 +106,7 @@ class Job:
             # Parse command line args
             args = self.proc.cmdline()
             assert len(args) > 4
-            assert 'python' in args[0]
+            assert 'python' in args[0] or 'Python' in args[0]
             assert 'chia' in args[1]
             assert 'plots' == args[2]
             assert 'create' == args[3]


### PR DESCRIPTION
Make a little change to support VSCode debugging.

1. While debugging in the vscode IDE on macOS, the process name of Python it "Python" not "python", so add additional check.

2. In addition, if the filename is unicode, the decode will cause exception, so change it from 'ascii' to 'utf-8'.

It can test with the following configuration in launch.json (in chia-blockchain workspace):

{
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Python: plotman",
            "type": "python",
            "request": "launch",
            "module": "plotman",
            "justMyCode": false,
            "args":["interactive"]
        }
    ]
}


