### PR TITLE
Plotman doesn't work if installed with experimental gui installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 venv
+src/plotman.egg-info/

--- a/src/plotman/configuration.py
+++ b/src/plotman/configuration.py
@@ -90,3 +90,4 @@ class PlotmanConfig:
     directories: Directories
     scheduling: Scheduling
     plotting: Plotting
+    gui_install: bool


### PR DESCRIPTION
## Plotman can't find jobs if it was installed with experimental gui installer

This has lots of unfortunate consequences like infinitely launching jobs :upside_down_face: 

+ Adds a `gui_install` flag to config file
+ Modifies `jobs.py` to search for jobs differently if the flag is set

## Testing (?)

Not sure how to test. Let me know the preferred way and I can run them. 