### PR TITLE
Show number of running jobs in the status command

### DIFF
--- a/src/plotman/reporting.py
+++ b/src/plotman/reporting.py
@@ -136,7 +136,7 @@ def status_report(jobs, width, height=None, tmp_prefix='', dst_prefix=''):
     ]
 
     # Number of jobs in each tmp disk
-    tmp_dir_paths = sorted(list(map(lambda job: abbr_path(job.tmpdir, tmp_prefix), jobs)))
+    tmp_dir_paths = sorted([abbr_path(job.tmpdir, tmp_prefix) for job in jobs])
     for key, group in groupby(tmp_dir_paths, lambda dir: dir):
         summary.append(
             'Jobs in {0}: {1}'.format(key, len(list(group)))

--- a/src/plotman/reporting.py
+++ b/src/plotman/reporting.py
@@ -3,6 +3,7 @@ import os
 
 import psutil
 import texttable as tt  # from somewhere?
+from itertools import groupby
 
 from plotman import archive, job, manager, plot_util
 
@@ -62,6 +63,8 @@ def job_viz(jobs):
     result += n_to_char(n_at_ph(jobs, (4, 0)))
     return result
 
+# Command: plotman status
+# Shows a general overview of all running jobs
 def status_report(jobs, width, height=None, tmp_prefix='', dst_prefix=''):
     '''height, if provided, will limit the number of rows in the table,
        showing first and last rows, row numbers and an elipsis in the middle.'''
@@ -85,10 +88,11 @@ def status_report(jobs, width, height=None, tmp_prefix='', dst_prefix=''):
     tab.set_cols_dtype('t' * len(headings))
     tab.set_cols_align('r' * len(headings))
     tab.set_header_align('r' * len(headings))
+
     for i, j in enumerate(sorted(jobs, key=job.Job.get_time_wall)):
         # Elipsis row
         if abbreviate_jobs_list and i == n_begin_rows:
-            row = ['...'] + ([''] * 13)
+            row = ['...'] + ([''] * len(headings) - 1)
         # Omitted row
         elif abbreviate_jobs_list and i > n_begin_rows and i < (len(jobs) - n_end_rows):
             continue
@@ -97,19 +101,19 @@ def status_report(jobs, width, height=None, tmp_prefix='', dst_prefix=''):
         else:
             try:
                 with j.proc.oneshot():
-                    row = [j.plot_id[:8],
-                        j.k,
-                        abbr_path(j.tmpdir, tmp_prefix),
-                        abbr_path(j.dstdir, dst_prefix),
-                        plot_util.time_format(j.get_time_wall()),
-                        phase_str(j.progress()),
-                        plot_util.human_format(j.get_tmp_usage(), 0),
-                        j.proc.pid,
-                        j.get_run_status(),
-                        plot_util.human_format(j.get_mem_usage(), 1),
-                        plot_util.time_format(j.get_time_user()),
-                        plot_util.time_format(j.get_time_sys()),
-                        plot_util.time_format(j.get_time_iowait())
+                    row = [j.plot_id[:8], # Plot ID
+                        j.k, # k size
+                        abbr_path(j.tmpdir, tmp_prefix), # Temp directory
+                        abbr_path(j.dstdir, dst_prefix), # Destination directory
+                        plot_util.time_format(j.get_time_wall()), # Time wall
+                        phase_str(j.progress()), # Overall progress (major:minor)
+                        plot_util.human_format(j.get_tmp_usage(), 0), # Current temp file size
+                        j.proc.pid, # System pid
+                        j.get_run_status(), # OS status for the job process
+                        plot_util.human_format(j.get_mem_usage(), 1), # Memory usage
+                        plot_util.time_format(j.get_time_user()), # user system time
+                        plot_util.time_format(j.get_time_sys()), # system time
+                        plot_util.time_format(j.get_time_iowait()) # io wait
                         ]
             except (psutil.NoSuchProcess, psutil.AccessDenied):
                 # In case the job has disappeared
@@ -122,8 +126,23 @@ def status_report(jobs, width, height=None, tmp_prefix='', dst_prefix=''):
 
     tab.set_max_width(width)
     tab.set_deco(0)  # No borders
-    # return ('tmp dir prefix: %s ; dst dir prefix: %s\n' % (tmp_prefix, dst_prefix)
-    return tab.draw()
+
+    result = tab.draw()
+
+    # Add some summarized info
+    summary = [
+        '\n',
+        'Total jobs: {0}'.format(len(jobs))
+    ]
+
+    # Number of jobs in each tmp disk
+    tmp_dir_paths = sorted(list(map(lambda job: abbr_path(job.tmpdir, tmp_prefix), jobs)))
+    for key, group in groupby(tmp_dir_paths, lambda dir: dir):
+        summary.append(
+            'Jobs in {0}: {1}'.format(key, len(list(group)))
+        )
+
+    return result + '\n'.join(summary)
 
 def tmp_dir_report(jobs, dir_cfg, sched_cfg, width, start_row=None, end_row=None, prefix=''):
     '''start_row, end_row let you split the table up if you want'''


### PR DESCRIPTION
Extend `plotman status` to include a summary of how many jobs are currently currning

```
 plot id    k           tmp           dst   wall   phase    tmp      pid   stat    mem   user    sys     io
69d378c6   32   /plot/disk1   /farm/disk1   1:52     1:5   171G   206372    SLP   4.0G   2:04   0:05    16s
0a05cce1   32   /plot/disk2   /farm/disk1   1:53     1:5   172G   206217    SLP   4.0G   2:11   0:05    12s
b125bec7   32   /plot/disk1   /farm/disk1   1:54     1:5   171G   206050    SLP   4.0G   2:05   0:05    21s
8eabd76b   32   /plot/disk2   /farm/disk1   1:55     1:5   172G   205851    SLP   4.1G   2:14   0:05    11s
706fb53f   32   /plot/disk1   /farm/disk1   1:58     1:5   172G   205347    SLP   4.0G   2:12   0:05    11s
55792166   32   /plot/disk2   /farm/disk1   3:26     2:1   169G   191975    RUN   1.3G   3:55   0:10   0:04
88ad605c   32   /plot/disk2   /farm/disk1   4:35     3:1   233G   187863    RUN   4.4G   5:03   0:12   0:09
07af8891   32   /plot/disk2   /farm/disk1   5:06     3:2   226G   187560    RUN   3.7G   5:26   0:13   0:19
4f0a0164   32   /plot/disk2   /farm/disk1   5:08     3:2   225G   187544    RUN   3.8G   5:30   0:14   0:19
78bd0279   32   /plot/disk2   /farm/disk1   5:10     3:2   222G   187520    DSK   3.8G   5:29   0:14   0:19

Total jobs: 10
Jobs in /plot/disk1: 3
Jobs in /plot/disk2: 7
```