### PR TITLE
req: allow archive to send to directory vs drives

### DIFF
--- a/src/plotman/_tests/archive_test.py
+++ b/src/plotman/_tests/archive_test.py
@@ -8,6 +8,7 @@ def test_compute_priority():
 def test_rsync_dest():
     arch_dir = '/plotdir/012'
     arch_cfg = configuration.Archive(
+        rsyncd_type='drives'
         rsyncd_module='plots_mod',
         rsyncd_path='/plotdir',
         rsyncd_host='thehostname',

--- a/src/plotman/configuration.py
+++ b/src/plotman/configuration.py
@@ -45,6 +45,7 @@ class Archive:
     rsyncd_bwlimit: int
     rsyncd_host: str
     rsyncd_user: str
+    rsyncd_type: str = 'drives' # Defaults to original drives method
     index: int = 0  # If not explicit, "index" will default to 0
 
 @dataclass

--- a/src/plotman/resources/plotman.yaml
+++ b/src/plotman/resources/plotman.yaml
@@ -62,6 +62,7 @@ directories:
         # host, and that the module is configured to match the local path.
         # See code for details.
         archive:
+                rsyncd_type: drives
                 rsyncd_module: plots
                 rsyncd_path: /plots
                 rsyncd_bwlimit: 80000  # Bandwidth limit in KB/s


### PR DESCRIPTION
Handles https://github.com/ericaltendorf/plotman/issues/321

The archiver currently requires separate drives to be mounted for archiving. For instance:

- /mnt (a folder on the root drive)
  - /mnt/drive1 (a physical drive/mount in `df`)

However, if you have a RAID or ZRAID where you are storing elements, there is no "mounted drive" to use. For instance:

- /storage (a RAID array with lots of items on it
  - /storage/random (some random files)
  - /storage/plots (where you want your plots to go)
  - /storage/morerandom (some random files)

This PR adds a new configuration option of `rsyncd_type` which defaults to `drives` if it does not exist in the configuration (the original method).

If it is set to `directory` in the configuration YAML, then:
- `df` checks free space on the destination directory without requiring it to be a separate mounted disk
- The same path replacements happen, which means the share name (ex: `chia`) would be the rsync destination, which in turn is the single directory destination

I've run this across 3 plots in testing, and all functions smoothly.