### PR TITLE
Avoid double counting jobs if chia was installed with binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 venv
 .DS_Store
 .vscode
+src/plotman.egg-info

--- a/src/plotman/job.py
+++ b/src/plotman/job.py
@@ -149,6 +149,8 @@ class Job:
                             parsed_command = parse_chia_plots_create_command_line(
                                 command_line=proc.cmdline(),
                             )
+                            if proc.parent().name() != 'chia':  # grab thread not parent
+                                continue                            
                             if parsed_command.error is not None:
                                 continue
                             job = Job(


### PR DESCRIPTION
If chia was installed with binaries, plotman will double count jobs. As you can see from the structure from below, there are two processes running for one job. (If someone could explain this, that'd be great)

![image](https://user-images.githubusercontent.com/23230902/117764614-a5a8e780-b1e1-11eb-948b-34b38eaf2eb4.png)

+ Adds a check in `job.py` to only count the child process.