### PR TITLE
removes unessisary arguments in psutil.pocess_iter in job.Job.get_running_jobs()

### DIFF
--- a/src/plotman/job.py
+++ b/src/plotman/job.py
@@ -137,7 +137,7 @@ class Job:
         jobs = []
         cached_jobs_by_pid = { j.proc.pid: j for j in cached_jobs }
 
-        for proc in psutil.process_iter(['pid', 'cmdline']):
+        for proc in psutil.process_iter():
             # Ignore processes which most likely have terminated between the time of
             # iteration and data access.
             with contextlib.suppress(psutil.NoSuchProcess, psutil.AccessDenied):


### PR DESCRIPTION
The attributes retrived with argumments (that is, 'pid' and 'cmdline') is not used, and getting 'cmdline' attribute with psutil from some processes on windows is unstable and throws exceptions.

It is impossible to catch exceptions from this line without abandoning the for lop. If we try to catch exception from this line, we will not get jobs from processes that comes after the exception, this will cause big problems, that is, running jobs that are not returned from get_running_jobs()!

It is better to get 'cmdline' and other attributes of processes inside the for loop, where exceptions can be handled without abandoning the for loop, that is, we can move on to processes that comes after the process that throws the exception.

Here is info about the exception that can be caused by this line:
OS: Windows 7
python version: 3.8.9
psutil: 5.8.0
This exception is caused by accessing 'cmdline' attribute on process 'audiodg.exe'.
Note that, sometimes 'audiodg.exe' is not present on the system, try to ajust audio volumn in the right of task bar, this will cause 'audiodg.exe' to run.

Here is the traceback:

```python-traceback
Traceback (most recent call last):
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python38\Scripts\plotman.exe\__main__.py", line 7, in <module>
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\plotman\plotman.py", line 162, in main
    jobs = Job.get_running_jobs(cfg.directories.log)
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\plotman\job.py", line 140, in get_running_jobs
    for proc in psutil.process_iter(['pid', 'cmdline']):
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\psutil\__init__.py", line 1439, in process_iter
    yield add(pid)
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\psutil\__init__.py", line 1416, in add
    proc.info = proc.as_dict(attrs=attrs, ad_value=ad_value)
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\psutil\__init__.py", line 525, in as_dict
    ret = meth()
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\psutil\__init__.py", line 677, in cmdline
    return self._proc.cmdline()
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\psutil\_pswindows.py", line 681, in wrapper
    raise convert_oserror(err, pid=self.pid, name=self._name)
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\psutil\_pswindows.py", line 671, in convert_oserror
    raise exc
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\psutil\_pswindows.py", line 679, in wrapper
    return fun(self, *args, **kwargs)
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\psutil\_pswindows.py", line 695, in wrapper
    return fun(self, *args, **kwargs)
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\psutil\_pswindows.py", line 787, in cmdline
    ret = cext.proc_cmdline(self.pid, use_peb=True)
OSError: [WinError 0] The operation completed successfully: '(originated from OpenProcess)'
```