### PR TITLE
~= install_requires deps (mostly)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,15 +36,15 @@ package_dir=
     =src
 packages=find:
 install_requires =
-    appdirs
-    attrs
-    click
-    desert
-    marshmallow
-    pendulum
+    appdirs ~= 1.4
+    attrs == 21.2
+    click ~= 7.1
+    desert == 2020.11.18
+    marshmallow ~= 3.12
+    pendulum ~= 2.1
     psutil ~= 5.8
-    pyyaml
-    texttable
+    pyyaml ~= 5.4
+    texttable ~= 1.6
 
 [options.packages.find]
 where=src


### PR DESCRIPTION
Since we still 'need' `--force-reinstall` until we get per-commit versioning, this will help pip not mess up the chia deps when we install into their env.

See #357