### PR TITLE
add global stager

### DIFF
--- a/src/plotman/configuration.py
+++ b/src/plotman/configuration.py
@@ -75,9 +75,12 @@ class Scheduling:
     global_max_jobs: int
     global_stagger_m: int
     polling_time_s: int
+    stagger_phase_major: int
+    stagger_phase_minor: int
     tmpdir_max_jobs: int
     tmpdir_stagger_phase_major: int
     tmpdir_stagger_phase_minor: int
+    stagger_phase_limit: int = 1  # If not explicit, "stagger_phase_limit" will default to 1
     tmpdir_stagger_phase_limit: int = 1  # If not explicit, "tmpdir_stagger_phase_limit" will default to 1
 
 @attr.frozen

--- a/src/plotman/job.py
+++ b/src/plotman/job.py
@@ -19,6 +19,9 @@ import psutil
 
 from plotman import chia
 
+def job_phases(all_jobs):
+    '''Return phase 2-tuples for ALL jobs running'''
+    return sorted([j.progress() for j in all_jobs])
 
 def job_phases_for_tmpdir(d, all_jobs):
     '''Return phase 2-tuples for jobs running on tmpdir d'''

--- a/src/plotman/resources/plotman.yaml
+++ b/src/plotman/resources/plotman.yaml
@@ -84,6 +84,16 @@ directories:
 
 # Plotting scheduling parameters
 scheduling:
+        # Run a job only if the number of existing jobs
+        # before stagger_phase_major stagger_phase_minor
+        # is less than stagger_phase_limit.
+        # Phase major corresponds to the plot phase, phase minor corresponds to
+        # the table or table pair in sequence, phase limit corresponds to
+        # the number of plots allowed before [phase major, phase minor]
+        stagger_phase_major: 2
+        stagger_phase_minor: 1
+        # Optional: default is 1
+        stagger_phase_limit: 1
         # Run a job on a particular temp dir only if the number of existing jobs
         # before [tmpdir_stagger_phase_major : tmpdir_stagger_phase_minor]
         # is less than tmpdir_stagger_phase_limit.


### PR DESCRIPTION
stager is a great way to manager CPU threads, but only stager for tmp directory is not enough to manage threads efficiently if I have multiple HDDs or SSDs, so I add a global stager, to use with multiple SSDs, and keep ALL threads used by running ploting won't exceed thread number of the computer.