### PR TITLE
fix: skip so-called plot processes that are parents of others

### DIFF
--- a/src/plotman/job.py
+++ b/src/plotman/job.py
@@ -148,6 +148,13 @@ class Job:
                     if is_plotting_cmdline(process.cmdline()):
                         processes.append(process)
 
+            # https://github.com/ericaltendorf/plotman/pull/418
+            # The experimental Chia GUI .deb installer launches plots
+            # in a manner that results in a parent and child process
+            # that both share the same command line and, as such, are
+            # both identified as plot processes.  Only the child is
+            # really plotting.  Filter out the parent.
+
             pids = {process.pid for process in processes}
             ppids = {process.ppid() for process in processes}
             wanted_pids = pids - ppids

--- a/src/plotman/job.py
+++ b/src/plotman/job.py
@@ -151,7 +151,6 @@ class Job:
             pids = {process.pid for process in processes}
             ppids = {process.ppid() for process in processes}
             wanted_pids = pids - ppids
-            # wanted_pids = pids
 
             wanted_processes = [
                 process


### PR DESCRIPTION
The new experimental Chia GUI installer launches plot processes
such that you end up with two processes with the exact same
command line.  This confuses us since we identify both as being
separate plot processes and report two when there's only one that
is actually interesting.

This fix identifies the parents of all the potential plotting
processes and removes them from the list of processes of interest.

https://github.com/ericaltendorf/plotman/issues/301
https://github.com/ericaltendorf/plotman/pull/330
https://github.com/ericaltendorf/plotman/issues/337
https://github.com/ericaltendorf/plotman/issues/405