### PR TITLE
adds -x parameter to plot command

### DIFF
--- a/src/plotman/configuration.py
+++ b/src/plotman/configuration.py
@@ -89,6 +89,7 @@ class Plotting:
     job_buffer: int
     farmer_pk: Optional[str] = None
     pool_pk: Optional[str] = None
+    x: bool = False
 
 @attr.frozen
 class UserInterface:

--- a/src/plotman/manager.py
+++ b/src/plotman/manager.py
@@ -128,6 +128,8 @@ def maybe_start_new_plot(dir_cfg, sched_cfg, plotting_cfg):
             if dir_cfg.tmp2 is not None:
                 plot_args.append('-2')
                 plot_args.append(dir_cfg.tmp2)
+            if plotting_cfg.x:
+                plot_args.append('-x')  
 
             logmsg = ('Starting plot job: %s ; logging to %s' % (' '.join(plot_args), logfile))
 

--- a/src/plotman/resources/plotman.yaml
+++ b/src/plotman/resources/plotman.yaml
@@ -123,3 +123,7 @@ plotting:
         # If specified, pass through to the -f and -p options.  See CLI reference.
         #   farmer_pk: ...
         #   pool_pk: ...
+        # If true, Skips adding [final dir] / dst to harvester for farming. 
+        # Especially useful if you have harvesters that are running somewhere else
+        # and you are just plotting on the machine where plotman is running.
+        #   x: True


### PR DESCRIPTION
Introduces the possibility to skip adding the dst / final_dir
to the harvester for farming.
Especially useful if you have harvesters that are running somewhere else
and you are just plotting on the machine where plotman is running.