### PR TITLE
adds logs printing command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#643](https://github.com/ericaltendorf/plotman/pull/643))
 - `plotman prometheus` command to output status for consumption by [Prometheus](https://prometheus.io/).
   ([#430](https://github.com/ericaltendorf/plotman/pull/430))
+- `plotman logs` command to print and tail plot logs by their plot ID.
+  ([#509](https://github.com/ericaltendorf/plotman/pull/509))
 
 ## [0.4.1] - 2021-06-11
 ### Fixed

--- a/src/plotman/job.py
+++ b/src/plotman/job.py
@@ -413,7 +413,7 @@ class Job:
             logfile = self.logfile
             )
 
-    def print_logs(self, follow=None):
+    def print_logs(self, follow: bool = False) -> None:
         with open(self.logfile, 'r') as f:
             if follow:
                 line = ''

--- a/src/plotman/job.py
+++ b/src/plotman/job.py
@@ -412,7 +412,23 @@ class Job:
             dst = self.dstdir,
             logfile = self.logfile
             )
-    
+
+    def print_logs(self, follow=None):
+        with open(self.logfile, 'r') as f:
+            if follow:
+                line = ''
+                while True:
+                    tmp = f.readline()
+                    if tmp is not None:
+                        line += tmp
+                        if line.endswith("\n"):
+                            print(line.rstrip('\n'))
+                            line = ''
+                    else:
+                        time.sleep(0.1)
+            else:
+                print(f.read())
+
     def to_dict(self) -> typing.Dict[str, object]:
         '''Exports important information as dictionary.'''
         return dict(

--- a/src/plotman/plotman.py
+++ b/src/plotman/plotman.py
@@ -62,6 +62,11 @@ class PlotmanArgParser:
         p_details = sp.add_parser('details', help='show details for job')
         self.add_idprefix_arg(p_details)
 
+        p_logs = sp.add_parser('logs', help='fetch the logs for job')
+
+        p_logs.add_argument('-f', '--follow', action='store_true', help='Follow log output')
+        self.add_idprefix_arg(p_logs)
+
         p_files = sp.add_parser('files', help='show temp files associated with job')
         self.add_idprefix_arg(p_files)
 
@@ -261,7 +266,7 @@ def main() -> None:
             #
             # Job control commands
             #
-            elif args.cmd in [ 'details', 'files', 'kill', 'suspend', 'resume' ]:
+            elif args.cmd in [ 'details', 'logs', 'files', 'kill', 'suspend', 'resume' ]:
                 print(args)
 
                 selected = []
@@ -283,6 +288,9 @@ def main() -> None:
                 for job in selected:
                     if args.cmd == 'details':
                         print(job.status_str_long())
+
+                    elif args.cmd == 'logs':
+                        job.print_logs(args.follow)
 
                     elif args.cmd == 'files':
                         temp_files = job.get_temp_files()


### PR DESCRIPTION
Introduces a logs command inspired by how `docker logs` works when interacting with containers but now for plots via plotman.
Basically I got sick of running `plotman status` then `plotman details` and afterwards `tail` or `less` for the given logfile. Now it is possible to simply print or follow the logs after getting the id of the plot via `plotman status`.