### PR TITLE
fix: removes unused import of readline module, it does not exist in Windows

### DIFF
--- a/src/plotman/manager.py
+++ b/src/plotman/manager.py
@@ -3,7 +3,7 @@ import operator
 import os
 import random
 import re
-import readline  # For nice CLI
+#import readline  # For nice CLI
 import subprocess
 import sys
 import time

--- a/src/plotman/manager.py
+++ b/src/plotman/manager.py
@@ -3,7 +3,6 @@ import operator
 import os
 import random
 import re
-#import readline  # For nice CLI
 import subprocess
 import sys
 import time


### PR DESCRIPTION
According to [Python Documentation](https://docs.python.org/3/library/readline.html), the readline module is an interface of GNU readline, which is [not available on Windows](https://stackoverflow.com/questions/51157443/pythons-readline-module-not-available-for-windows).

There is an alternative package [pyreadline](https://pypi.org/project/pyreadline/) which is cross platform.

Tested on:
OS: Windows 7
Python: 3.8.9

```
PS C:\Users\Administrator> plotman status
Traceback (most recent call last):
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python38\Scripts\plotman.exe\__main__.py", line 4, in <module>
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\plotman\plotman.py", line 10, in <module>
    from plotman import analyzer, archive, configuration, interactive, manager, plot_util, reporting
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\plotman\archive.py", line 15, in <module>
    from plotman import job, manager, plot_util
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\plotman\manager.py", line 6, in <module>
    import readline  # For nice CLI
ModuleNotFoundError: No module named 'readline'
```

