### PR TITLE
Start job windows

### DIFF
--- a/src/plotman/archive.py
+++ b/src/plotman/archive.py
@@ -14,6 +14,8 @@ import texttable as tt
 
 from plotman import job, manager, plot_util
 
+_WINDOWS = sys.platform == 'win32'
+
 # TODO : write-protect and delete-protect archived plots
 
 def spawn_archive_process(dir_cfg, all_jobs):
@@ -38,7 +40,8 @@ def spawn_archive_process(dir_cfg, all_jobs):
                     shell=True,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.STDOUT,
-                    start_new_session=True)
+                    start_new_session=True,
+                    creationflags=0 if not _WINDOWS else subprocess.CREATE_NO_WINDOW)
             log_message = 'Starting archive: ' + cmd
             # At least for now it seems that even if we get a new running
             # archive jobs list it doesn't contain the new rsync process.

--- a/src/plotman/manager.py
+++ b/src/plotman/manager.py
@@ -22,7 +22,7 @@ HR = 3600   # Seconds
 
 MAX_AGE = 1000_000_000   # Arbitrary large number of seconds
 
-_WINDOWS = os.name == 'nt'
+_WINDOWS = sys.platform == 'win32'
 
 def dstdirs_to_furthest_phase(all_jobs):
     '''Return a map from dst dir to a phase tuple for the most progressed job
@@ -174,7 +174,7 @@ def maybe_start_new_plot(dir_cfg, sched_cfg, plotting_cfg):
                     stdout=open_log_file,
                     stderr=subprocess.STDOUT,
                     start_new_session=True,
-                    creationflags = 0 if not _WINDOWS else subprocess.CREATE_NO_WINDOW)
+                    creationflags=0 if not _WINDOWS else subprocess.CREATE_NO_WINDOW)
 
             psutil.Process(p.pid).nice(15 if not _WINDOWS else psutil.BELOW_NORMAL_PRIORITY_CLASS)
             return (True, logmsg)

--- a/src/plotman/manager.py
+++ b/src/plotman/manager.py
@@ -23,6 +23,8 @@ HR = 3600   # Seconds
 
 MAX_AGE = 1000_000_000   # Arbitrary large number of seconds
 
+_WINDOWS = os.name == 'nt'
+
 def dstdirs_to_furthest_phase(all_jobs):
     '''Return a map from dst dir to a phase tuple for the most progressed job
        that is emitting to that dst dir.'''
@@ -162,10 +164,14 @@ def maybe_start_new_plot(dir_cfg, sched_cfg, plotting_cfg):
 
             with open_log_file:
                 # start_new_sessions to make the job independent of this controlling tty.
+                # start_new_sessions to make the job independent of this controlling tty (POSIX only).
+                # subprocess.CREATE_NO_WINDOW to make the process independent of this controlling tty and have no console window on Windows.
                 p = subprocess.Popen(plot_args,
                     stdout=open_log_file,
                     stderr=subprocess.STDOUT,
                     start_new_session=True)
+                    start_new_session=True,
+                    creationflags = 0 if not _WINDOWS else subprocess.CREATE_NO_WINDOW)
 
             psutil.Process(p.pid).nice(15)
             return (True, logmsg)

--- a/src/plotman/manager.py
+++ b/src/plotman/manager.py
@@ -163,13 +163,11 @@ def maybe_start_new_plot(dir_cfg, sched_cfg, plotting_cfg):
             # allowing handling of just the log file opening error.
 
             with open_log_file:
-                # start_new_sessions to make the job independent of this controlling tty.
                 # start_new_sessions to make the job independent of this controlling tty (POSIX only).
                 # subprocess.CREATE_NO_WINDOW to make the process independent of this controlling tty and have no console window on Windows.
                 p = subprocess.Popen(plot_args,
                     stdout=open_log_file,
                     stderr=subprocess.STDOUT,
-                    start_new_session=True)
                     start_new_session=True,
                     creationflags = 0 if not _WINDOWS else subprocess.CREATE_NO_WINDOW)
 

--- a/src/plotman/manager.py
+++ b/src/plotman/manager.py
@@ -171,7 +171,7 @@ def maybe_start_new_plot(dir_cfg, sched_cfg, plotting_cfg):
                     start_new_session=True,
                     creationflags = 0 if not _WINDOWS else subprocess.CREATE_NO_WINDOW)
 
-            psutil.Process(p.pid).nice(15)
+            psutil.Process(p.pid).nice(15 if not _WINDOWS else psutil.BELOW_NORMAL_PRIORITY_CLASS)
             return (True, logmsg)
 
     return (False, wait_reason)


### PR DESCRIPTION
For line:
`creationflags = 0 if not _WINDOWS else subprocess.CREATE_NO_WINDOW`

I tested plotman on Windows 7 and discovered that jobs started by plotman will be terminated if I close the terminal window that runs the plotman when the job was started.

After reading [the documentation of subprocess.Popen](https://docs.python.org/3/library/subprocess.html#popen-constructor),  it turns out that `start_new_session` is POSIX only.

We have to use `creationflags` to make the job process independent.

for the line:
`psutil.Process(p.pid).nice(15 if not _WINDOWS else psutil.BELOW_NORMAL_PRIORITY_CLASS)`

OS: Windows 7
Python: 3.8.9

An exception was thrown:
```
Traceback (most recent call last):
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python38\Scripts\plotman.exe\__main__.py", line 7, in <module>
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\plotman\plotman.py", line 177, in main
    interactive.run_interactive()
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\plotman\interactive.py", line 334, in run_interactive
    curses.wrapper(curses_main)
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\curses\__init__.py", line 105, in wrapper
    return func(stdscr, *args, **kwds)
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\plotman\interactive.py", line 117, in curses_main
    (started, msg) = manager.maybe_start_new_plot(
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\plotman\manager.py", line 170, in maybe_start_new_plot
    psutil.Process(p.pid).nice(15)
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\psutil\__init__.py", line 724, in nice
    self._proc.nice_set(value)
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\psutil\_pswindows.py", line 681, in wrapper
    raise convert_oserror(err, pid=self.pid, name=self._name)
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\psutil\_pswindows.py", line 671, in convert_oserror
    raise exc
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\psutil\_pswindows.py", line 679, in wrapper
    return fun(self, *args, **kwargs)
  File "c:\users\administrator\appdata\local\programs\python\python38\lib\site-packages\psutil\_pswindows.py", line 1016, in nice_set
    return cext.proc_priority_set(self.pid, value)
OSError: [WinError 87] The parameter is incorrect.
```

It turns out windows have specifc priority values. As shown from [documentation of psutil.Process.nice](https://psutil.readthedocs.io/en/latest/#psutil.Process.nice).

