### PR TITLE
Add Dockerfile for dockerizing plotman

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.github
+.coveragerc
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ghcr.io/chia-network/chia:latest
+COPY . /plotman
+ENV PATH="/chia-blockchain/venv/bin:$PATH"
+RUN apt update && \
+    apt install pip -y && \
+    rm -rf /var/lib/apt/lists && \
+    pip install -e /plotman


### PR DESCRIPTION
I created a Dockerfile that adds plotman to the chia-docker image. (https://github.com/Chia-Network/chia-docker)

I've got a build image here: https://hub.docker.com/r/carlallen/chia-plotman