### PR TITLE
fix: avoid more missing process errors

### DIFF
--- a/src/plotman/job.py
+++ b/src/plotman/job.py
@@ -140,12 +140,17 @@ class Job:
         with contextlib.ExitStack() as exit_stack:
             processes = []
 
+            pids = set()
+            ppids = set()
+
             for process in psutil.process_iter():
                 # Ignore processes which most likely have terminated between the time of
                 # iteration and data access.
                 with contextlib.suppress(psutil.NoSuchProcess, psutil.AccessDenied):
                     exit_stack.enter_context(process.oneshot())
                     if is_plotting_cmdline(process.cmdline()):
+                        ppids.add(process.ppid())
+                        pids.add(process.pid)
                         processes.append(process)
 
             # https://github.com/ericaltendorf/plotman/pull/418
@@ -155,8 +160,6 @@ class Job:
             # both identified as plot processes.  Only the child is
             # really plotting.  Filter out the parent.
 
-            pids = {process.pid for process in processes}
-            ppids = {process.ppid() for process in processes}
             wanted_pids = pids - ppids
 
             wanted_processes = [
@@ -166,23 +169,24 @@ class Job:
             ]
 
             for proc in wanted_processes:
-                if proc.pid in cached_jobs_by_pid.keys():
-                    jobs.append(cached_jobs_by_pid[proc.pid])  # Copy from cache
-                else:
-                    with proc.oneshot():
-                        parsed_command = parse_chia_plots_create_command_line(
-                            command_line=proc.cmdline(),
-                        )
-                        if parsed_command.error is not None:
-                            continue
-                        job = Job(
-                            proc=proc,
-                            parsed_command=parsed_command,
-                            logroot=logroot,
-                        )
-                        if job.help:
-                            continue
-                        jobs.append(job)
+                with contextlib.suppress(psutil.NoSuchProcess, psutil.AccessDenied):
+                    if proc.pid in cached_jobs_by_pid.keys():
+                        jobs.append(cached_jobs_by_pid[proc.pid])  # Copy from cache
+                    else:
+                        with proc.oneshot():
+                            parsed_command = parse_chia_plots_create_command_line(
+                                command_line=proc.cmdline(),
+                            )
+                            if parsed_command.error is not None:
+                                continue
+                            job = Job(
+                                proc=proc,
+                                parsed_command=parsed_command,
+                                logroot=logroot,
+                            )
+                            if job.help:
+                                continue
+                            jobs.append(job)
 
         return jobs
 


### PR DESCRIPTION
I misunderstand https://psutil.readthedocs.io/en/latest/#psutil.Process.oneshot to be a complete cache of all data taken at the time of entering the context manager.  As I think about it, this is silly.  There's way too much info that would take way too long and the vast majority would be unused in most cases, etc.  Nope, it caches data _when_ it, or adjacent tidbits, are requested.  Still useful, but doesn't protect against the `psutil.NoSuchProcess` error.

```python-traceback
Traceback (most recent call last):
  File "/farm/venv/lib/python3.9/site-packages/psutil/_common.py", line 447, in wrapper
    ret = self._cache[fun]
KeyError: <function Process.ppid at 0x7fee6029edc0>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/farm/venv/lib/python3.9/site-packages/psutil/_common.py", line 447, in wrapper
    ret = self._cache[fun]
KeyError: <function Process._parse_stat_file at 0x7fee6029a8b0>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/farm/venv/lib/python3.9/site-packages/psutil/_pslinux.py", line 1576, in wrapper
    return fun(self, *args, **kwargs)
  File "/farm/venv/lib/python3.9/site-packages/psutil/_common.py", line 454, in wrapper
    ret = self._cache[fun] = fun(self)
  File "/farm/venv/lib/python3.9/site-packages/psutil/_pslinux.py", line 1618, in _parse_stat_file
    with open_binary("%s/%s/stat" % (self._procfs_path, self.pid)) as f:
  File "/farm/venv/lib/python3.9/site-packages/psutil/_common.py", line 711, in open_binary
    return open(fname, "rb", **kwargs)
FileNotFoundError: [Errno 2] No such file or directory: '/proc/9500/stat'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/chia/.local/bin/plotman", line 33, in <module>
    sys.exit(load_entry_point('plotman', 'console_scripts', 'plotman')())
  File "/farm/plotman/src/plotman/plotman.py", line 179, in main
    interactive.run_interactive()
  File "/farm/plotman/src/plotman/interactive.py", line 335, in run_interactive
    curses.wrapper(curses_main)
  File "/home/chia/.pyenv/versions/3.9.2/lib/python3.9/curses/__init__.py", line 94, in wrapper
    return func(stdscr, *args, **kwds)
  File "/farm/plotman/src/plotman/interactive.py", line 110, in curses_main
    jobs = Job.get_running_jobs(cfg.directories.log, cached_jobs=jobs)
  File "/farm/plotman/src/plotman/job.py", line 159, in get_running_jobs
    ppids = {process.ppid() for process in processes}
  File "/farm/plotman/src/plotman/job.py", line 159, in <setcomp>
    ppids = {process.ppid() for process in processes}
  File "/farm/venv/lib/python3.9/site-packages/psutil/_common.py", line 454, in wrapper
    ret = self._cache[fun] = fun(self)
  File "/farm/venv/lib/python3.9/site-packages/psutil/__init__.py", line 605, in ppid
    return self._proc.ppid()
  File "/farm/venv/lib/python3.9/site-packages/psutil/_pslinux.py", line 1576, in wrapper
    return fun(self, *args, **kwargs)
  File "/farm/venv/lib/python3.9/site-packages/psutil/_pslinux.py", line 2142, in ppid
    return int(self._parse_stat_file()['ppid'])
  File "/farm/venv/lib/python3.9/site-packages/psutil/_pslinux.py", line 1583, in wrapper
    raise NoSuchProcess(self.pid, self._name)
psutil.NoSuchProcess: psutil.NoSuchProcess process no longer exists (pid=9500, name='chia')
```