### PR TITLE
Archive balancing based on rsync temp files

### DIFF
--- a/src/plotman/archive.py
+++ b/src/plotman/archive.py
@@ -161,9 +161,24 @@ def archive(dir_cfg, all_jobs):
     archdir = ''
     available = [(d, space) for (d, space) in archdir_freebytes.items() if
                  space > 1.2 * plot_util.get_k32_plotsize()]
+
     if len(available) > 0:
-        index = min(dir_cfg.archive.index, len(available) - 1)
-        (archdir, freespace) = sorted(available)[index]
+        for candidate in available:
+            # Check if there is an rsync temp file here. TODO maybe use find or a regex
+            # pattern or make the pattern configurable, or even find better documentation on rsync temp files.
+            # Making it configurable would fit better with upcoming changes to opening up the archive process,
+            # Assuming that custom process created a tmp file and cleaned up after itself
+            temp_cmd = ('ssh %s@%s ls -h %s/.plot*.plot.* 2>/dev/null' %
+                            (dir_cfg.archive.rsyncd_user, dir_cfg.archive.rsyncd_host, candidate[0]) )
+
+            with subprocess.Popen(temp_cmd, shell=True, stdout=subprocess.PIPE) as proc:
+                # Assumes the command returns nothing if no temp files are found (hence the supression of stderr)
+                # This needs work because what if it is the ssh command that fails?
+                if len(proc.stdout.readlines()):
+                    continue
+
+            (archdir, freespace) = candidate
+            break
 
     if not archdir:
         return(False, 'No archive directories found with enough free space')

--- a/src/plotman/configuration.py
+++ b/src/plotman/configuration.py
@@ -55,7 +55,6 @@ class Archive:
     rsyncd_bwlimit: int
     rsyncd_host: str
     rsyncd_user: str
-    index: int = 0  # If not explicit, "index" will default to 0
 
 @attr.frozen
 class TmpOverrides:

--- a/src/plotman/resources/plotman.yaml
+++ b/src/plotman/resources/plotman.yaml
@@ -6,7 +6,7 @@ user_interface:
         # relying on what is reported by the curses library.   In some cases,
         # the curses library fails to update on SIGWINCH signals.  If the
         # `plotman interactive` curses interface does not properly adjust when
-        # you resize the terminal window, you can try setting this to True. 
+        # you resize the terminal window, you can try setting this to True.
         use_stty_size: True
 
 # Where to plot and log.
@@ -51,7 +51,7 @@ directories:
         # use all of them.  These again are presumed to be on independent
         # physical devices so writes (plot jobs) and reads (archivals) can
         # be scheduled to minimize IO contention.
-        # 
+        #
         # If dst is commented out, the tmp directories will be used as the
         # buffer.
         dst:
@@ -74,16 +74,6 @@ directories:
                 rsyncd_bwlimit: 80000  # Bandwidth limit in KB/s
                 rsyncd_host: myfarmer
                 rsyncd_user: chia
-                # Optional index.  If omitted or set to 0, plotman will archive
-                # to the first archive dir with free space.  If specified,
-                # plotman will skip forward up to 'index' drives (if they exist).
-                # This can be useful to reduce io contention on a drive on the
-                # archive host if you have multiple plotters (simultaneous io
-                # can still happen at the time a drive fills up.)  E.g., if you
-                # have four plotters, you could set this to 0, 1, 2, and 3, on
-                # the 4 machines, or 0, 1, 0, 1.
-                #   index: 0
-
 
 # Plotting scheduling parameters
 scheduling:
@@ -126,7 +116,7 @@ plotting:
         # If specified, pass through to the -f and -p options.  See CLI reference.
         #   farmer_pk: ...
         #   pool_pk: ...
-        # If true, Skips adding [final dir] / dst to harvester for farming. 
+        # If true, Skips adding [final dir] / dst to harvester for farming.
         # Especially useful if you have harvesters that are running somewhere else
         # and you are just plotting on the machine where plotman is running.
         #   x: True


### PR DESCRIPTION
Proof of concept. Makes a few assumptions that might not be valid across all the different platforms and won't work with some of the other changes here on opening up the archive process to other commands.

Idea:

Say you have 10Gbe (or more) and you have multiple plotman instances running on your network and you want to archive to a single server with more disks shared than plotman instances. When the archive routine runs, it'll get the list of destinations that has free disk space (as it did before). It'll then look to see if rsync temp file pattern is there, indicating a different plotman instance is archiving there. If it finds it, it'll try a different destination. This will balance the copies across disks.

It still has 1 archive process per plotman instance so it won't help in those situations.

Edit: Resuming partial transfers would probably fail because it might not go back to the same drive as before, so that invalidates the -P option on rsync. A way around that would be to adjust the logic to look for a file that has the same base name as the copy source. I might look into that.

NOTE: I have made these changes against the development branch, but I don't run the development branch at home.  For the moment, I'm just hand patching changes into the main branch and when they work, I put them here. If you try to merge these or run this fork directly, there might be an issue. If there is, let me know and I'll fix it.