### PR TITLE
pool support

### DIFF
--- a/src/plotman/chia.py
+++ b/src/plotman/chia.py
@@ -303,3 +303,58 @@ def _cli():
 # end copied code
 def _cli():
     pass
+
+
+@commands.register(version=(1, 1, 7))
+@click.command()
+# https://github.com/Chia-Network/chia-blockchain/blob/1.1.7/LICENSE
+# https://github.com/Chia-Network/chia-blockchain/blob/1.1.7/chia/cmds/plots.py#L39-L83
+# start copied code
+@click.option("-k", "--size", help="Plot size", type=int, default=32, show_default=True)
+@click.option("--override-k", help="Force size smaller than 32", default=False, show_default=True, is_flag=True)
+@click.option("-n", "--num", help="Number of plots or challenges", type=int, default=1, show_default=True)
+@click.option("-b", "--buffer", help="Megabytes for sort/plot buffer", type=int, default=3389, show_default=True)
+@click.option("-r", "--num_threads", help="Number of threads to use", type=int, default=2, show_default=True)
+@click.option("-u", "--buckets", help="Number of buckets", type=int, default=128, show_default=True)
+@click.option(
+    "-a",
+    "--alt_fingerprint",
+    type=int,
+    default=None,
+    help="Enter the alternative fingerprint of the key you want to use",
+)
+@click.option(
+    "-c",
+    "--pool_contract_address",
+    type=str,
+    default=None,
+    help="Address of where the pool reward will be sent to. Only used if alt_fingerprint and pool public key are None",
+)
+@click.option("-f", "--farmer_public_key", help="Hex farmer public key", type=str, default=None)
+@click.option("-p", "--pool_public_key", help="Hex public key of pool", type=str, default=None)
+@click.option(
+    "-t",
+    "--tmp_dir",
+    help="Temporary directory for plotting files",
+    type=click.Path(),
+    default=Path("."),
+    show_default=True,
+)
+@click.option("-2", "--tmp2_dir", help="Second temporary directory for plotting files", type=click.Path(), default=None)
+@click.option(
+    "-d",
+    "--final_dir",
+    help="Final directory for plots (relative or absolute)",
+    type=click.Path(),
+    default=Path("."),
+    show_default=True,
+)
+@click.option("-i", "--plotid", help="PlotID in hex for reproducing plots (debugging only)", type=str, default=None)
+@click.option("-m", "--memo", help="Memo in hex for reproducing plots (debugging only)", type=str, default=None)
+@click.option("-e", "--nobitfield", help="Disable bitfield", default=False, is_flag=True)
+@click.option(
+    "-x", "--exclude_final_dir", help="Skips adding [final dir] to harvester for farming", default=False, is_flag=True
+)
+# end copied code
+def _cli():
+    pass

--- a/src/plotman/chia.py
+++ b/src/plotman/chia.py
@@ -248,3 +248,58 @@ def _cli():
 # end copied code
 def _cli():
     pass
+
+
+@commands.register(version=(1, 1, 6))
+@click.command()
+# https://github.com/Chia-Network/chia-blockchain/blob/1.1.6/LICENSE
+# https://github.com/Chia-Network/chia-blockchain/blob/1.1.6/chia/cmds/plots.py#L39-L83
+# start copied code
+@click.option("-k", "--size", help="Plot size", type=int, default=32, show_default=True)
+@click.option("--override-k", help="Force size smaller than 32", default=False, show_default=True, is_flag=True)
+@click.option("-n", "--num", help="Number of plots or challenges", type=int, default=1, show_default=True)
+@click.option("-b", "--buffer", help="Megabytes for sort/plot buffer", type=int, default=3389, show_default=True)
+@click.option("-r", "--num_threads", help="Number of threads to use", type=int, default=2, show_default=True)
+@click.option("-u", "--buckets", help="Number of buckets", type=int, default=128, show_default=True)
+@click.option(
+    "-a",
+    "--alt_fingerprint",
+    type=int,
+    default=None,
+    help="Enter the alternative fingerprint of the key you want to use",
+)
+@click.option(
+    "-c",
+    "--pool_contract_address",
+    type=str,
+    default=None,
+    help="Address of where the pool reward will be sent to. Only used if alt_fingerprint and pool public key are None",
+)
+@click.option("-f", "--farmer_public_key", help="Hex farmer public key", type=str, default=None)
+@click.option("-p", "--pool_public_key", help="Hex public key of pool", type=str, default=None)
+@click.option(
+    "-t",
+    "--tmp_dir",
+    help="Temporary directory for plotting files",
+    type=click.Path(),
+    default=Path("."),
+    show_default=True,
+)
+@click.option("-2", "--tmp2_dir", help="Second temporary directory for plotting files", type=click.Path(), default=None)
+@click.option(
+    "-d",
+    "--final_dir",
+    help="Final directory for plots (relative or absolute)",
+    type=click.Path(),
+    default=Path("."),
+    show_default=True,
+)
+@click.option("-i", "--plotid", help="PlotID in hex for reproducing plots (debugging only)", type=str, default=None)
+@click.option("-m", "--memo", help="Memo in hex for reproducing plots (debugging only)", type=str, default=None)
+@click.option("-e", "--nobitfield", help="Disable bitfield", default=False, is_flag=True)
+@click.option(
+    "-x", "--exclude_final_dir", help="Skips adding [final dir] to harvester for farming", default=False, is_flag=True
+)
+# end copied code
+def _cli():
+    pass

--- a/src/plotman/configuration.py
+++ b/src/plotman/configuration.py
@@ -107,6 +107,7 @@ class Plotting:
     job_buffer: int
     farmer_pk: Optional[str] = None
     pool_pk: Optional[str] = None
+    pool_contract_address: Optional[str] = None
     x: bool = False
 
 @attr.frozen

--- a/src/plotman/manager.py
+++ b/src/plotman/manager.py
@@ -130,6 +130,9 @@ def maybe_start_new_plot(dir_cfg, sched_cfg, plotting_cfg):
             if plotting_cfg.pool_pk is not None:
                 plot_args.append('-p')
                 plot_args.append(plotting_cfg.pool_pk)
+            if plotting_cfg.pool_contract_address is not None:
+                plot_args.append('-c')
+                plot_args.append(plotting_cfg.pool_contract_address)
             if dir_cfg.tmp2 is not None:
                 plot_args.append('-2')
                 plot_args.append(dir_cfg.tmp2)


### PR DESCRIPTION
This is \_not\_ for replotting support such as automatically deleting non-poolable plots.  If that is done it will be done separately.

Draft for:
- [ ] What else do we need to do?
- [x] Does the cli parser need updated?
- [ ] What should we do in response to this to help avoid not-working configurations?
  - `Address of where the pool reward will be to. Only used if alt_fingerprint and public key are None`
  - The plot process does raise an exception so the hazard is limited to plotting not launching rather than a bunch of plots being created in a way other than expected.
    - `RuntimeError: Choose one of pool_contract_address and pool_public_key`