### PR TITLE
Improve kill command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support the [madMAx plotter](https://github.com/madMAx43v3r/chia-plotter).
   See the [configuration wiki page](https://github.com/ericaltendorf/plotman/wiki/Configuration#2-v05) for help setting it up.
   ([#797](https://github.com/ericaltendorf/plotman/pull/797))
+- Added argument `-f / --force` to `plotman kill` to skip confirmation before killing the job
+
+### Fixed
+- `plotman kill` doesn't leave any temporary files behind anymore
 
 ## [0.4.1] - 2021-06-11
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support the [madMAx plotter](https://github.com/madMAx43v3r/chia-plotter).
   See the [configuration wiki page](https://github.com/ericaltendorf/plotman/wiki/Configuration#2-v05) for help setting it up.
   ([#797](https://github.com/ericaltendorf/plotman/pull/797))
-- Added argument `-f / --force` to `plotman kill` to skip confirmation before killing the job
+- Added argument `-f`/`--force` to `plotman kill` to skip confirmation before killing the job.
 
 ### Fixed
 - `plotman kill` doesn't leave any temporary files behind anymore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+### Fixed
+- `plotman kill` doesn't leave any temporary files behind anymore.
+  ([#801](https://github.com/ericaltendorf/plotman/pull/801))
 ### Added
 - `plotman export` command to output summaries from plot logs in `.csv` format.
   ([#557](https://github.com/ericaltendorf/plotman/pull/557))
@@ -21,9 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   See the [configuration wiki page](https://github.com/ericaltendorf/plotman/wiki/Configuration#2-v05) for help setting it up.
   ([#797](https://github.com/ericaltendorf/plotman/pull/797))
 - Added argument `-f`/`--force` to `plotman kill` to skip confirmation before killing the job.
-
-### Fixed
-- `plotman kill` doesn't leave any temporary files behind anymore
+  ([#801](https://github.com/ericaltendorf/plotman/pull/801))
 
 ## [0.4.1] - 2021-06-11
 ### Fixed

--- a/src/plotman/job.py
+++ b/src/plotman/job.py
@@ -559,7 +559,7 @@ class Job:
 
         for dir in [self.tmpdir, self.tmp2dir, self.dstdir]:
             if dir is not None:
-                temp_files.update(glob.glob(os.path.join(dir, "plot-*-{0}.*".format(self.plot_id))))
+                temp_files.update(glob.glob(os.path.join(dir, f"plot-*-{self.plot_id}.*")))
 
         return temp_files
 

--- a/src/plotman/job.py
+++ b/src/plotman/job.py
@@ -7,6 +7,7 @@ import os
 import random
 import re
 import sys
+import glob
 import time
 from datetime import datetime
 from enum import Enum, auto
@@ -555,13 +556,11 @@ class Job:
     def get_temp_files(self) -> typing.Set[str]:
         # Prevent duplicate file paths by using set.
         temp_files = set([])
-        for f in self.proc.open_files():
-            if any(
-                dir in f.path
-                for dir in [self.tmpdir, self.tmp2dir, self.dstdir]
-                if dir is not None
-            ):
-                temp_files.add(f.path)
+
+        for dir in [self.tmpdir, self.tmp2dir, self.dstdir]:
+            if dir is not None:
+                temp_files.update(glob.glob(os.path.join(dir, "plot-*-{0}.*".format(self.plot_id))))
+
         return temp_files
 
     def cancel(self) -> None:

--- a/src/plotman/job.py
+++ b/src/plotman/job.py
@@ -559,7 +559,7 @@ class Job:
 
         for dir in [self.tmpdir, self.tmp2dir, self.dstdir]:
             if dir is not None:
-                temp_files.update(glob.glob(os.path.join(dir, f"plot-*-{self.plot_id}.*")))
+                temp_files.update(glob.glob(os.path.join(dir, f"plot-*-{self.plot_id}.tmp")))
 
         return temp_files
 

--- a/src/plotman/plotman.py
+++ b/src/plotman/plotman.py
@@ -73,6 +73,7 @@ class PlotmanArgParser:
         self.add_idprefix_arg(p_files)
 
         p_kill = sp.add_parser('kill', help='kill job (and cleanup temp files)')
+        p_kill.add_argument('-f', '--force', action='store_true', default=False, help="Don't ask for confirmation before killing the plot job")
         self.add_idprefix_arg(p_kill)
 
         p_suspend = sp.add_parser('suspend', help='suspend job')
@@ -309,15 +310,23 @@ def main() -> None:
                         job.suspend()
 
                         temp_files = job.get_temp_files()
-                        print('Will kill pid %d, plot id %s' % (job.proc.pid, job.plot_id))
-                        print('Will delete %d temp files' % len(temp_files))
-                        conf = input('Are you sure? ("y" to confirm): ')
-                        if (conf != 'y'):
-                            print('canceled.  If you wish to resume the job, do so manually.')
+                        
+                        if args.force:
+                            conf = 'y'
                         else:
+                            conf = input('Are you sure? ("y" to confirm): ')
+
+                        if (conf != 'y'):
+                            print('Canceled.  If you wish to resume the job, do so manually.')
+                        else:
+                            print('Will kill pid %d, plot id %s' % (job.proc.pid, job.plot_id))
+                            print('Will delete %d temp files' % len(temp_files))
                             print('killing...')
+
                             job.cancel()
+
                             print('cleaning up temp files...')
+
                             for f in temp_files:
                                 os.remove(f)
 

--- a/src/plotman/plotman.py
+++ b/src/plotman/plotman.py
@@ -311,6 +311,9 @@ def main() -> None:
 
                         temp_files = job.get_temp_files()
                         
+                        print('Will kill pid %d, plot id %s' % (job.proc.pid, job.plot_id))
+                        print('Will delete %d temp files' % len(temp_files))
+
                         if args.force:
                             conf = 'y'
                         else:
@@ -319,8 +322,6 @@ def main() -> None:
                         if (conf != 'y'):
                             print('Canceled.  If you wish to resume the job, do so manually.')
                         else:
-                            print('Will kill pid %d, plot id %s' % (job.proc.pid, job.plot_id))
-                            print('Will delete %d temp files' % len(temp_files))
                             print('killing...')
 
                             job.cancel()


### PR DESCRIPTION
This PR adds two improvements to `plotman kill`:

1. Adds `-f` to proceed without asking for confirmation
2. Delete the files based on filesystem pattern instead of using `open_files()`, as it always left something behind. 