### PR TITLE
- fix Job.is_plotting_cmdline for MadMax

### DIFF
--- a/src/plotman/job.py
+++ b/src/plotman/job.py
@@ -39,7 +39,7 @@ def is_plotting_cmdline(cmdline: typing.List[str]) -> bool:
             and 'plots' == cmdline[1]
             and 'create' == cmdline[2]
         )
-    elif cmdline and 'chia_plot' == cmdline[0].lower():  # Madmax plotter
+    elif cmdline and 'chia_plot' == os.path.basename(cmdline[0].lower()):  # Madmax plotter
         return True
     return False
 


### PR DESCRIPTION
  - only basename of the process name should be compared
    (it can contain full path to binary, or './' etc)

