### PR TITLE
Docker improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 .coveragerc
 .gitignore
 docker
+!docker/supervisord.conf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#869](https://github.com/ericaltendorf/plotman/pull/869))
 - A combined major/minor value for Prometheus status output.
   ([#885](https://github.com/ericaltendorf/plotman/pull/885))
+- `supervisord` now used in Docker image.
+  ([#898](https://github.com/ericaltendorf/plotman/pull/898))
 
 ## [0.5.1] - 2021-07-15
 ### Fixed

--- a/build-docker-plotman.sh
+++ b/build-docker-plotman.sh
@@ -7,15 +7,15 @@ BASE_CONTAINER="ubuntu:20.04"
 CHIA_GIT_REFERENCE="1.2.3"
 
 # The UID/GID should match the 'chia' owner of the directories on the host system
-bUID=10001
-bGID=10001
+build_UID=10001
+build_GID=10001
 
 docker build . \
 	--squash \
 	--build-arg BASE_CONTAINER=${BASE_CONTAINER} \
 	--build-arg CHIA_GIT_REFERENCE=${CHIA_GIT_REFERENCE} \
-	--build-arg UID=${bUID} \
-	--build-arg GID=${bGID} \
+	--build-arg UID=${build_UID} \
+	--build-arg GID=${build_GID} \
 	-f docker/Dockerfile \
         -t ${DOCKER_REGISTRY}/${PROJECT}:${TAG}
 

--- a/build-docker-plotman.sh
+++ b/build-docker-plotman.sh
@@ -2,22 +2,20 @@
 
 DOCKER_REGISTRY="<docker-registry>"
 PROJECT="chia-plotman"
-TAG="plotter"
+TAG="latest"
 BASE_CONTAINER="ubuntu:20.04"
-CHIA_GIT_REFERENCE="1.1.7"
+CHIA_GIT_REFERENCE="1.2.3"
 
 # The UID/GID should match the 'chia' owner of the directories on the host system
-UID=10001
-GID=10001
-
-docker rmi ${LOCAL_REGISTRY}/${PROJECT}:${TAG}
+bUID=10001
+bGID=10001
 
 docker build . \
 	--squash \
 	--build-arg BASE_CONTAINER=${BASE_CONTAINER} \
 	--build-arg CHIA_GIT_REFERENCE=${CHIA_GIT_REFERENCE} \
-	--build-arg UID=${UID} \
-	--build-arg GID=${GID} \
+	--build-arg UID=${bUID} \
+	--build-arg GID=${bGID} \
 	-f docker/Dockerfile \
         -t ${DOCKER_REGISTRY}/${PROJECT}:${TAG}
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN /bin/bash ./install.sh
 
 COPY . /plotman
 
-RUN ["/bin/bash", "-c", "source ./activate && pip install /plotman && deactivate"] 
+RUN ["/bin/bash", "-c", "source ./activate && pip install /plotman && pip install supervisor && deactivate"]
 
 # Build deployment container
 FROM ${BASE_CONTAINER} as plotman
@@ -31,6 +31,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
 && rm -rf /var/lib/apt/lists
 
 COPY --from=plotman-builder /chia-blockchain /chia-blockchain
+COPY ./docker/supervisord.conf /srv/supervisord.conf
 
 RUN groupadd -g ${GID} chia
 RUN useradd -m -u ${UID} -g ${GID} chia
@@ -50,7 +51,7 @@ USER chia
 ENV VIRTUAL_ENV="/chia-blockchain/venv"
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Kick off plots (assumes the environemnt is good to go)
-CMD ["/bin/bash", "-c", "plotman plot" ]
+# Kick off plots & archives (assumes the environemnt is good to go)
+CMD ["/chia-blockchain/venv/bin/supervisord", "-c", "/srv/supervisord.conf" ]
 # Alternative command to simply provide shell environment
 # CMD ["/bin/bash", "-c", "trap : TERM INT; sleep infinity & wait" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN /bin/bash ./install.sh
 
 COPY . /plotman
 
-RUN ["/bin/bash", "-c", "source ./activate && pip install /plotman && pip install supervisor && deactivate"]
+RUN ["/bin/bash", "-c", "source ./activate && pip install /plotman supervisor && deactivate"]
 
 # Build deployment container
 FROM ${BASE_CONTAINER} as plotman

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,0 +1,10 @@
+[supervisord]
+nodaemon=true
+
+[program:plot]
+command=plotman plot
+redirect_stderr=true
+
+[program:archive]
+command=plotman archive
+redirect_stderr=true

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -3,8 +3,6 @@ nodaemon=true
 
 [program:plot]
 command=plotman plot
-redirect_stderr=true
 
 [program:archive]
 command=plotman archive
-redirect_stderr=true


### PR DESCRIPTION
Use supervisord to run both plotting & archiving by default. This can easily be overridden by volume mounting a replacement `/srv/supervisord.conf`

- Suggest default tagging the image as `latest` since it's the Docker default and often has a special meaning in orchestration.
- Update Chia reference to latest stable
- Avoid clobbering $UID which can have unintended consequences