### PR TITLE
Enhance Madmax arguments to support plotting for Chives

### DIFF
--- a/src/plotman/analyzer.py
+++ b/src/plotman/analyzer.py
@@ -163,7 +163,9 @@ def analyze(
                     )
                 )
             elif len(values) == 1:
-                row.append(plot_util.human_format(values[0], 1))
+                row.append(values[0])  # Use exact time in seconds.
+                # Due to Madmax and Bladebit speed, don't round times in seconds to nearest thousands
+                #row.append(plot_util.human_format(values[0], 1))
             else:
                 row.append("N/A")
 

--- a/src/plotman/plotman.py
+++ b/src/plotman/plotman.py
@@ -162,7 +162,7 @@ class PlotmanArgParser:
 
 
 def get_term_width(cfg: configuration.PlotmanConfig) -> int:
-    default_columns = 120  # 80 is typically too narrow.
+    default_columns = 160  # 80 is typically too narrow, support wider consoles.
     if cfg.user_interface.use_stty_size:
         try:
             (rows_string, columns_string) = os.popen("stty size", "r").read().split()

--- a/src/plotman/plotters/madmax.py
+++ b/src/plotman/plotters/madmax.py
@@ -17,6 +17,7 @@ import plotman.plotters
 @attr.frozen
 class Options:
     executable: str = "chia_plot"
+    n: int = 1
     k: int = 32
     n_threads: int = 4
     n_buckets: int = 256
@@ -53,9 +54,9 @@ def create_command_line(
     pool_contract_address: typing.Optional[str],
 ) -> typing.List[str]:
     args = [
-        options.executable,
+        options.executable if options.k <= 32 else 'chia_plot_k34',
         "-n",
-        str(1),
+        str(options.n),
          "-k",
         str(options.k),
         "-r",
@@ -164,13 +165,13 @@ class Plotter:
         if len(command_line) == 0:
             return False
 
-        return "chia_plot" == os.path.basename(command_line[0]).lower()
+        return os.path.basename(command_line[0]).lower().startswith("chia_plot")
 
     def common_info(self) -> plotman.plotters.CommonInfo:
         return self.info.common()
 
     def parse_command_line(self, command_line: typing.List[str], cwd: str) -> None:
-        # drop the chia_plot
+        # drop the chia_plot or chia_plot_k34
         arguments = command_line[1:]
 
         # TODO: We could at some point do chia version detection and pick the
@@ -661,15 +662,15 @@ def _cli_974d6e5f1440f68c48492122ca33828a98864dfc() -> None:
 def _cli_aaa3214d4abbd49bb99c2ec087e27c765424cd65() -> None:
     pass
 
-# Madmax Git on 2021-10-12 -> https://github.com/madMAx43v3r/chia-plotter/commit/a9f35cd605517a8c134e7bb4e2af88dd3d3ac236
+# Madmax Git on 2021-10-28 -> https://github.com/madMAx43v3r/chia-plotter/commit/8332d625220b9a54c097d85d6eb4c6b0c9464214
 @commands.register(version=(3,))
 @click.command()
-# https://github.com/madMAx43v3r/chia-plotter/blob/a9f35cd605517a8c134e7bb4e2af88dd3d3ac236/LICENSE
-# https://github.com/madMAx43v3r/chia-plotter/blob/a9f35cd605517a8c134e7bb4e2af88dd3d3ac236/src/chia_plot.cpp#L238-L253
+# https://github.com/madMAx43v3r/chia-plotter/blob/8332d625220b9a54c097d85d6eb4c6b0c9464214/LICENSE
+# https://github.com/madMAx43v3r/chia-plotter/blob/8332d625220b9a54c097d85d6eb4c6b0c9464214/src/chia_plot.cpp#L238-L253
 @click.option(
     "-k",
     "--size",
-    help="K size (default = 32, k <= 32)",
+    help="K size (default = 32, supports 29,30,31,32,34)",
     type=int,
     default=32,
     show_default=True,
@@ -763,5 +764,5 @@ def _cli_aaa3214d4abbd49bb99c2ec087e27c765424cd65() -> None:
     type=int,
     default=1,
 )
-def _cli_a9f35cd605517a8c134e7bb4e2af88dd3d3ac236() -> None:
+def _cli_8332d625220b9a54c097d85d6eb4c6b0c9464214() -> None:
     pass

--- a/src/plotman/plotters/madmax.py
+++ b/src/plotman/plotters/madmax.py
@@ -18,7 +18,6 @@ import plotman.plotters
 class Options:
     executable: str = "chia_plot"
     k: typing.Optional[int] = 32
-    n_count: int = 1
     n_threads: int = 4
     n_buckets: int = 256
     n_buckets3: int = 256

--- a/src/plotman/plotters/madmax.py
+++ b/src/plotman/plotters/madmax.py
@@ -17,11 +17,15 @@ import plotman.plotters
 @attr.frozen
 class Options:
     executable: str = "chia_plot"
+    k: typing.Optional[int] = 32
+    n_count: int = 1
     n_threads: int = 4
     n_buckets: int = 256
     n_buckets3: int = 256
     n_rmulti2: int = 1
-
+    network_port: int = 8444
+    tmptoggle: bool = False
+    waitforcopy: bool = False
 
 def check_configuration(
     options: Options, pool_contract_address: typing.Optional[str]
@@ -53,10 +57,14 @@ def create_command_line(
         options.executable,
         "-n",
         str(1),
+         "-k",
+        str(options.k),
         "-r",
         str(options.n_threads),
         "-u",
         str(options.n_buckets),
+        "-x",
+        str(options.network_port),
         "-t",
         tmpdir if tmpdir.endswith("/") else (tmpdir + "/"),
         "-d",
@@ -71,6 +79,10 @@ def create_command_line(
     if options.n_rmulti2 is not None:
         args.append("-K")
         args.append(str(options.n_rmulti2))
+    if options.tmptoggle:
+        args.append("-G")
+    if options.waitforcopy:
+        args.append("-w")
 
     if farmer_public_key is not None:
         args.append("-f")
@@ -648,4 +660,109 @@ def _cli_974d6e5f1440f68c48492122ca33828a98864dfc() -> None:
     default=1,
 )
 def _cli_aaa3214d4abbd49bb99c2ec087e27c765424cd65() -> None:
+    pass
+
+# Madmax Git on 2021-10-12 -> https://github.com/madMAx43v3r/chia-plotter/commit/a9f35cd605517a8c134e7bb4e2af88dd3d3ac236
+@commands.register(version=(3,))
+@click.command()
+# https://github.com/madMAx43v3r/chia-plotter/blob/a9f35cd605517a8c134e7bb4e2af88dd3d3ac236/LICENSE
+# https://github.com/madMAx43v3r/chia-plotter/blob/a9f35cd605517a8c134e7bb4e2af88dd3d3ac236/src/chia_plot.cpp#L238-L253
+@click.option(
+    "-k",
+    "--size",
+    help="K size (default = 32, k <= 32)",
+    type=int,
+    default=32,
+    show_default=True,
+)
+@click.option(
+    "-x",
+    "--port",
+    help="Network port (default = 8444, chives = 9699)",
+    type=int,
+    default=8444,
+    show_default=True,
+)
+@click.option(
+    "-n",
+    "--count",
+    help="Number of plots to create (default = 1, -1 = infinite)",
+    type=int,
+    default=1,
+    show_default=True,
+)
+@click.option(
+    "-r",
+    "--threads",
+    help="Number of threads (default = 4)",
+    type=int,
+    default=4,
+    show_default=True,
+)
+@click.option(
+    "-u",
+    "--buckets",
+    help="Number of buckets (default = 256)",
+    type=int,
+    default=256,
+    show_default=True,
+)
+@click.option(
+    "-v",
+    "--buckets3",
+    help="Number of buckets for phase 3+4 (default = buckets)",
+    type=int,
+    default=256,
+)
+@click.option(
+    "-t",
+    "--tmpdir",
+    help="Temporary directory, needs ~220 GiB (default = $PWD)",
+    type=click.Path(),
+    default=pathlib.Path("."),
+    show_default=True,
+)
+@click.option(
+    "-2",
+    "--tmpdir2",
+    help="Temporary directory 2, needs ~110 GiB [RAM] (default = <tmpdir>)",
+    type=click.Path(),
+    default=None,
+)
+@click.option(
+    "-d",
+    "--finaldir",
+    help="Final directory (default = <tmpdir>)",
+    type=click.Path(),
+    default=pathlib.Path("."),
+    show_default=True,
+)
+@click.option(
+    "-w",
+    "--waitforcopy",
+    help="Wait for copy to start next plot",
+    type=bool,
+    default=False,
+    show_default=True,
+)
+@click.option(
+    "-p", "--poolkey", help="Pool Public Key (48 bytes)", type=str, default=None
+)
+@click.option(
+    "-c", "--contract", help="Pool Contract Address (62 chars)", type=str, default=None
+)
+@click.option(
+    "-f", "--farmerkey", help="Farmer Public Key (48 bytes)", type=str, default=None
+)
+@click.option(
+    "-G", "--tmptoggle", help="Alternate tmpdir/tmpdir2", type=str, default=None
+)
+@click.option(
+    "-K",
+    "--rmulti2",
+    help="Thread multiplier for P2 (default = 1)",
+    type=int,
+    default=1,
+)
+def _cli_a9f35cd605517a8c134e7bb4e2af88dd3d3ac236() -> None:
     pass

--- a/src/plotman/plotters/madmax.py
+++ b/src/plotman/plotters/madmax.py
@@ -349,10 +349,11 @@ def tmp2_dir(match: typing.Match[str], info: SpecificInfo) -> SpecificInfo:
 
 
 @handlers.register(
-    expression=r"^Plot Name: (?P<name>plot-k(?P<size>\d+)-(?P<year>\d+)-(?P<month>\d+)-(?P<day>\d+)-(?P<hour>\d+)-(?P<minute>\d+)-(?P<plot_id>\w+))$"
+    expression=r"^Plot Name: (?P<name>plot(-mmx)?-k(?P<size>\d+)-(?P<year>\d+)-(?P<month>\d+)-(?P<day>\d+)-(?P<hour>\d+)-(?P<minute>\d+)-(?P<plot_id>\w+))$"
 )
 def plot_name_line(match: typing.Match[str], info: SpecificInfo) -> SpecificInfo:
     # Plot Name: plot-k32-2021-07-11-16-52-3a3872f5a124497a17fb917dfe027802aa1867f8b0a8cbac558ed12aa5b697b2
+    # Plot Name: plot-mmx-k30-2022-01-03-19-44-06982c6179c6242979b68d81950577017d4594f59ec0e6859e83c7f9141cbc35
     return attr.evolve(
         info,
         plot_size=int(match.group("size")),

--- a/src/plotman/plotters/madmax.py
+++ b/src/plotman/plotters/madmax.py
@@ -17,7 +17,7 @@ import plotman.plotters
 @attr.frozen
 class Options:
     executable: str = "chia_plot"
-    k: typing.Optional[int] = 32
+    k: int = 32
     n_threads: int = 4
     n_buckets: int = 256
     n_buckets3: int = 256


### PR DESCRIPTION
Adds the `-x` (network port) and `-k` (plot size) options to Madmax plotter configuration.  Also includes the boolean toggles of `-w` (wait for copy) and `-G` (tmp toggle).  Tested this in order to create the smaller k29/k30/k31 size plots that the Chives blockchain fork uses.

Each of these new options is fully optional so their absence in existing plotman.yaml config files will simply continue to use the previous implicit defaults.  This means no impact to existing Plotman users.